### PR TITLE
feat: group multiple borrows per market into single loan

### DIFF
--- a/packages/aave-core/src/aave.ts
+++ b/packages/aave-core/src/aave.ts
@@ -163,18 +163,22 @@ export function buildLoanPositions(
 
     const collateralSupplies = suppliedAssets.filter((asset) => asset.collateralEnabled);
 
-    return borrowedAssets
-      .map((borrowed, index) => ({
-        id: `${marketName}-${borrowed.address}-${index}`,
+    if (borrowedAssets.length === 0 && collateralSupplies.length === 0) return [];
+
+    const totalBorrowedUsd = borrowedAssets.reduce((sum, asset) => sum + asset.usdValue, 0);
+    const totalSuppliedUsd = collateralSupplies.reduce((sum, asset) => sum + asset.usdValue, 0);
+
+    if (totalBorrowedUsd < MIN_POSITION_USD && totalSuppliedUsd < MIN_POSITION_USD) return [];
+
+    return [
+      {
+        id: marketName,
         marketName,
-        borrowed,
+        borrowed: borrowedAssets,
         supplied: collateralSupplies,
-        totalBorrowedUsd: borrowed.usdValue,
-        totalSuppliedUsd: collateralSupplies.reduce((sum, asset) => sum + asset.usdValue, 0),
-      }))
-      .filter(
-        (loan) =>
-          loan.totalBorrowedUsd >= MIN_POSITION_USD || loan.totalSuppliedUsd >= MIN_POSITION_USD,
-      );
+        totalBorrowedUsd,
+        totalSuppliedUsd,
+      },
+    ];
   });
 }

--- a/packages/aave-core/src/metrics.ts
+++ b/packages/aave-core/src/metrics.ts
@@ -90,10 +90,10 @@ export function parseDeployRate(value: string | undefined, defaultRate: number):
 
 export function computeAdjustedHF(loan: LoanPosition): AdjustedHFResult {
   const debt = loan.totalBorrowedUsd;
-  const borrowedSymbol = loan.borrowed.symbol;
+  const borrowedSymbols = new Set(loan.borrowed.map((b) => b.symbol));
 
-  const nonSameAssets = loan.supplied.filter((asset) => asset.symbol !== borrowedSymbol);
-  const sameAssets = loan.supplied.filter((asset) => asset.symbol === borrowedSymbol);
+  const nonSameAssets = loan.supplied.filter((asset) => !borrowedSymbols.has(asset.symbol));
+  const sameAssets = loan.supplied.filter((asset) => borrowedSymbols.has(asset.symbol));
 
   const adjustedCollateralUSD = nonSameAssets.reduce((sum, asset) => sum + asset.usdValue, 0);
   const adjustedLt = weightedAverage(nonSameAssets, (asset) => asset.liqThreshold);
@@ -162,7 +162,7 @@ export function computeLoanMetrics(loan: LoanPosition | null, rDeploy: number): 
   const ltvMax = weightedAverage(loan.supplied, (asset) => asset.maxLTV);
   const lt = weightedAverage(loan.supplied, (asset) => asset.liqThreshold);
   const rSupply = weightedAverage(loan.supplied, (asset) => asset.supplyRate);
-  const rBorrow = loan.borrowed.borrowRate;
+  const rBorrow = weightedAverage(loan.borrowed, (asset) => asset.borrowRate);
 
   const ltv = collateralUSD > 0 ? debt / collateralUSD : 0;
   const leverage = equity > 0 ? collateralUSD / equity : Infinity;

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -52,7 +52,7 @@ export type AssetPosition = {
 export type LoanPosition = {
   id: string;
   marketName: string;
-  borrowed: AssetPosition;
+  borrowed: AssetPosition[];
   supplied: AssetPosition[];
   totalSuppliedUsd: number;
   totalBorrowedUsd: number;

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -356,7 +356,7 @@ export class Monitor {
     label: string | undefined,
     loan: {
       marketName: string;
-      borrowed: { symbol: string };
+      borrowed: { symbol: string }[];
       totalBorrowedUsd: number;
       totalSuppliedUsd: number;
     },
@@ -377,7 +377,7 @@ export class Monitor {
       '',
       `Wallet: <code>${walletLabel}</code>`,
       `Market: ${loan.marketName}`,
-      `Borrowed: $${loan.totalBorrowedUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })} ${loan.borrowed.symbol} | Collateral: $${loan.totalSuppliedUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`,
+      `Borrowed: $${loan.totalBorrowedUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })} ${loan.borrowed.map((b) => b.symbol).join('+')} | Collateral: $${loan.totalSuppliedUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`,
       '',
       `Health Factor: <b>${hf}</b> · Adjusted: <b>${adjHf}</b>`,
       `Zone: ${zone.emoji} ${zone.label} (was ${previousZone.emoji} ${previousZone.label})`,
@@ -397,7 +397,7 @@ export class Monitor {
   private formatRecovery(
     address: string,
     label: string | undefined,
-    loan: { marketName: string; borrowed: { symbol: string } },
+    loan: { marketName: string; borrowed: { symbol: string }[] },
     metrics: { healthFactor: number; adjustedHF: number },
     zone: Zone,
     previousZone: Zone,
@@ -410,7 +410,7 @@ export class Monitor {
       `${zone.emoji} <b>IMPROVING</b> — Zone Recovery`,
       '',
       `Wallet: <code>${walletLabel}</code>`,
-      `Market: ${loan.marketName} · ${loan.borrowed.symbol}`,
+      `Market: ${loan.marketName} · ${loan.borrowed.map((b) => b.symbol).join('+')}`,
       `Health Factor: <b>${hf}</b> · Adjusted: <b>${adjHf}</b>`,
       `Zone: ${zone.emoji} ${zone.label} (was ${previousZone.emoji} ${previousZone.label})`,
     ].join('\n');
@@ -419,7 +419,7 @@ export class Monitor {
   private formatAllClear(
     address: string,
     label: string | undefined,
-    loan: { marketName: string; borrowed: { symbol: string } },
+    loan: { marketName: string; borrowed: { symbol: string }[] },
     metrics: { healthFactor: number; adjustedHF: number },
   ): string {
     const walletLabel = label ? `${label} (${this.shortAddr(address)})` : this.shortAddr(address);
@@ -430,7 +430,7 @@ export class Monitor {
       `\u{1F7E2} <b>ALL CLEAR</b> — Back to Safe`,
       '',
       `Wallet: <code>${walletLabel}</code>`,
-      `Market: ${loan.marketName} · ${loan.borrowed.symbol}`,
+      `Market: ${loan.marketName} · ${loan.borrowed.map((b) => b.symbol).join('+')}`,
       `Health Factor: <b>${hf}</b> · Adjusted: <b>${adjHf}</b>`,
       '',
       `All positions are healthy. Monitoring continues.`,
@@ -440,7 +440,7 @@ export class Monitor {
   private formatReminder(
     address: string,
     label: string | undefined,
-    loan: { marketName: string; borrowed: { symbol: string } },
+    loan: { marketName: string; borrowed: { symbol: string }[] },
     metrics: { healthFactor: number; adjustedHF: number },
     zone: Zone,
     stuckDurationMs: number,
@@ -454,7 +454,7 @@ export class Monitor {
       `${zone.emoji} <b>REMINDER</b> — Still in ${zone.label} zone`,
       '',
       `Wallet: <code>${walletLabel}</code>`,
-      `Market: ${loan.marketName} · ${loan.borrowed.symbol}`,
+      `Market: ${loan.marketName} · ${loan.borrowed.map((b) => b.symbol).join('+')}`,
       `Health Factor: <b>${hf}</b> · Adjusted: <b>${adjHf}</b>`,
       `Duration: ${timeAgo} ago`,
       `Action: ${zone.action}`,

--- a/packages/server/test/watchdog-integration.test.ts
+++ b/packages/server/test/watchdog-integration.test.ts
@@ -41,19 +41,21 @@ function createLoan(overrides: Partial<LoanPosition> = {}): LoanPosition {
   return {
     id: 'loan-1',
     marketName: 'proto_mainnet_v3',
-    borrowed: {
-      symbol: 'USDC',
-      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-      decimals: 6,
-      amount: 1600,
-      usdPrice: 1,
-      usdValue: 1600,
-      collateralEnabled: false,
-      maxLTV: 0,
-      liqThreshold: 0,
-      supplyRate: 0,
-      borrowRate: 0.05,
-    },
+    borrowed: [
+      {
+        symbol: 'USDC',
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        decimals: 6,
+        amount: 1600,
+        usdPrice: 1,
+        usdValue: 1600,
+        collateralEnabled: false,
+        maxLTV: 0,
+        liqThreshold: 0,
+        supplyRate: 0,
+        borrowRate: 0.05,
+      },
+    ],
     supplied: [
       {
         symbol: 'WBTC',

--- a/packages/server/test/watchdog.test.ts
+++ b/packages/server/test/watchdog.test.ts
@@ -28,19 +28,21 @@ function createLoan(): LoanPosition {
   return {
     id: 'loan-1',
     marketName: 'proto_mainnet_v3',
-    borrowed: {
-      symbol: 'USDC',
-      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-      decimals: 6,
-      amount: 1600,
-      usdPrice: 1,
-      usdValue: 1600,
-      collateralEnabled: false,
-      maxLTV: 0,
-      liqThreshold: 0,
-      supplyRate: 0,
-      borrowRate: 0.05,
-    },
+    borrowed: [
+      {
+        symbol: 'USDC',
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        decimals: 6,
+        amount: 1600,
+        usdPrice: 1,
+        usdValue: 1600,
+        collateralEnabled: false,
+        maxLTV: 0,
+        liqThreshold: 0,
+        supplyRate: 0,
+        borrowRate: 0.05,
+      },
+    ],
     supplied: [
       {
         symbol: 'WBTC',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -363,21 +363,24 @@ export default function App() {
       return;
     }
 
-    const storageKey = buildBorrowRateHistoryKey(
-      selectedLoan.marketName,
-      selectedLoan.borrowed.address,
+    if (selectedLoan.borrowed.length === 0) {
+      setSelectedReserveTelemetry(null);
+      setReserveTelemetryError('');
+      setBorrowRateHistory([]);
+      return;
+    }
+
+    const primaryBorrow = selectedLoan.borrowed.reduce((max, b) =>
+      b.usdValue > max.usdValue ? b : max,
     );
+    const storageKey = buildBorrowRateHistoryKey(selectedLoan.marketName, primaryBorrow.address);
     setBorrowRateHistory(readBorrowRateHistory(storageKey));
 
     let cancelled = false;
     setSelectedReserveTelemetry(null);
     setReserveTelemetryError('');
 
-    void fetchReserveTelemetry(
-      selectedLoan.marketName,
-      selectedLoan.borrowed.address,
-      selectedLoan.borrowed.symbol,
-    )
+    void fetchReserveTelemetry(selectedLoan.marketName, primaryBorrow.address, primaryBorrow.symbol)
       .then((telemetry) => {
         if (cancelled) return;
 
@@ -403,13 +406,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [
-    result?.lastUpdated,
-    selectedLoan?.borrowed.address,
-    selectedLoan?.borrowed.symbol,
-    selectedLoan?.marketName,
-    selectedLoan,
-  ]);
+  }, [result?.lastUpdated, selectedLoan?.marketName, selectedLoan]);
 
   const handleFetch = async (event: FormEvent) => {
     event.preventDefault();
@@ -627,7 +624,8 @@ export default function App() {
                       size="sm"
                       onClick={() => setSelectedLoanId(loan.id)}
                     >
-                      Loan {index + 1}: {loan.marketName} · {loan.borrowed.symbol}
+                      Loan {index + 1}: {loan.marketName} ·{' '}
+                      {loan.borrowed.map((b) => b.symbol).join(' + ')}
                     </Button>
                   ))}
                 </nav>
@@ -640,10 +638,22 @@ export default function App() {
                       </CardTitle>
                     </CardHeader>
                     <CardContent>
-                      <StaticField
-                        label="Borrowed asset"
-                        value={`${fmtAmount(selectedLoan?.borrowed.amount ?? 0)} ${selectedLoan?.borrowed.symbol ?? ''}`}
-                      />
+                      <div className="grid min-w-0 gap-1.5 text-sm">
+                        <span className="text-muted-foreground">Borrowed assets</span>
+                        <ul className="grid list-none gap-1.5">
+                          {selectedLoan?.borrowed.map((asset) => (
+                            <li
+                              key={`${asset.address}-${asset.symbol}`}
+                              className="flex justify-between gap-2.5 rounded-lg border border-border bg-accent px-3 py-2 max-[980px]:flex-col max-[980px]:items-start"
+                            >
+                              <span className="font-medium">{asset.symbol}</span>
+                              <span className="text-muted-foreground">
+                                {fmtAmount(asset.amount)} | {fmtUSD(asset.usdValue, 0)}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                       <StaticField label="Market" value={selectedLoan?.marketName ?? '—'} />
                       <StaticField label="Debt (USD)" value={fmtUSD(computed.debt, 0)} />
                       <Separator />


### PR DESCRIPTION
## Summary
- Changed `LoanPosition.borrowed` from a single `AssetPosition` to `AssetPosition[]`, grouping all borrows within a market into one loan position (matching Aave's dashboard behavior)
- Dashboard now shows borrowed assets as a list (like supplied collateral), with loan tabs displaying combined symbols (e.g., "USDT + USDC")
- Borrow rate and adjusted HF computations updated to handle multiple borrows via weighted averages

## Test plan
- [x] All 33 existing tests pass with updated fixtures
- [x] TypeScript typecheck passes across all workspaces
- [x] ESLint and Prettier pass
- [x] Manual: verify dashboard shows multi-borrow loans as single card
- [ ] Manual: verify Telegram alerts display combined borrow symbols
- [ ] Manual: verify utilization curve/borrow APR charts load for primary borrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)