### PR TITLE
feat: show accrued interest for loan positions (Morpho)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Frontend notes:
 - The dashboard's `Total Assets`, `Net worth`, `Supply APY`, `Net earnings`, and `Net APY` include Morpho vault deposits; `HF`, `Borrow power used`, and `Repay coverage` remain loan-only.
 - Top-level portfolio metrics use hover/focus tooltips to explain their calculation in one sentence.
 - The loan positions table is sortable. It defaults to USD debt descending and supports sorting by market, collateral, borrowed asset, HF, rate, LTV, and liquidation price.
+- The loan positions table includes an `Accrued Int.` column (sortable) sourced from protocol position APIs when available (currently Morpho-only and API-dependent).
 - Portfolio `Net borrow cost` displays the gross annual loan borrow interest cost before supply earnings or Morpho vault income offsets.
 - The portfolio card labeled `Repay coverage` is based on wallet-held balances of tokens that also appear in the loan's borrowed asset set; it does not include unrelated wallet assets or vault deposits.
 - The utilization curve and borrow APR history charts depend on the Express API server for on-chain reserve telemetry. Without `yarn dev:server` (or the unified Docker/server runtime), those charts fall back to an unavailable message.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A React + Vite dashboard that auto-loads Aave loans, Morpho Blue market position
   - Liquidation price (primary-collateral approximation)
   - LTV, leverage, borrow headroom
   - Carry / Net APY summary, including loan net earnings offset by Morpho vault net income and gross annual borrow cost
+  - Loan table `Accrued Int.` column for borrowed positions when provided by the upstream protocol API (currently populated for Morpho positions when available)
   - Separate Morpho vault table with deposited asset amount, USD value, net APY, and shares
   - Aave interest-rate model chart for the selected borrowed asset, including current utilization and the reserve kink
   - Borrow APR history chart for the selected borrowed asset, built from locally stored reserve telemetry samples

--- a/packages/aave-core/src/morpho.ts
+++ b/packages/aave-core/src/morpho.ts
@@ -37,6 +37,8 @@ type MorphoHistoricalState = {
 type MorphoMarketPositionState = {
   borrowAssets: string;
   borrowAssetsUsd: number | null;
+  accruedBorrowInterest?: string | null;
+  accruedBorrowInterestUsd?: number | null;
   supplyAssets: string;
   supplyAssetsUsd: number | null;
   collateral: string;
@@ -57,6 +59,8 @@ export type RawMorphoMarketPosition = {
   state?: MorphoMarketPositionState;
   borrowAssets?: string;
   borrowAssetsUsd?: number | null;
+  accruedBorrowInterest?: string | null;
+  accruedBorrowInterestUsd?: number | null;
   supplyAssets?: string;
   supplyAssetsUsd?: number | null;
   collateral?: string;
@@ -153,6 +157,8 @@ const MORPHO_POSITIONS_QUERY = `
         state {
           borrowAssets
           borrowAssetsUsd
+          accruedBorrowInterest
+          accruedBorrowInterestUsd
           supplyAssets
           supplyAssetsUsd
           collateral
@@ -272,6 +278,9 @@ function positionState(pos: RawMorphoMarketPosition): MorphoMarketPositionState 
   return {
     borrowAssets: pos.state?.borrowAssets ?? pos.borrowAssets ?? '0',
     borrowAssetsUsd: pos.state?.borrowAssetsUsd ?? pos.borrowAssetsUsd ?? null,
+    accruedBorrowInterest: pos.state?.accruedBorrowInterest ?? pos.accruedBorrowInterest ?? null,
+    accruedBorrowInterestUsd:
+      pos.state?.accruedBorrowInterestUsd ?? pos.accruedBorrowInterestUsd ?? null,
     supplyAssets: pos.state?.supplyAssets ?? pos.supplyAssets ?? '0',
     supplyAssetsUsd: pos.state?.supplyAssetsUsd ?? pos.supplyAssetsUsd ?? null,
     collateral: pos.state?.collateral ?? pos.collateral ?? '0',
@@ -360,6 +369,7 @@ function buildMorphoMarketLoans(positions: RawMorphoMarketPosition[]): LoanPosit
     const borrowed = borrow ? [borrow] : [];
     const totalSuppliedUsd = supplied.reduce((sum, a) => sum + a.usdValue, 0);
     const totalBorrowedUsd = borrowed.reduce((sum, a) => sum + a.usdValue, 0);
+    const accruedBorrowInterestUsd = positionState(pos).accruedBorrowInterestUsd ?? undefined;
 
     if (totalSuppliedUsd < MIN_POSITION_USD && totalBorrowedUsd < MIN_POSITION_USD) return [];
 
@@ -386,6 +396,7 @@ function buildMorphoMarketLoans(positions: RawMorphoMarketPosition[]): LoanPosit
         supplied,
         totalSuppliedUsd,
         totalBorrowedUsd,
+        accruedBorrowInterestUsd,
         morphoMarketParams,
         utilizationRate: pos.market.state.utilization,
         marketSupplyApy: pos.market.state.supplyApy,

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -80,6 +80,8 @@ export type LoanPosition = {
   supplied: AssetPosition[];
   totalSuppliedUsd: number;
   totalBorrowedUsd: number;
+  /** Borrow interest accrued in USD for this position when available from the upstream protocol API. */
+  accruedBorrowInterestUsd?: number;
   morphoMarketParams?: MorphoMarketParams;
   /** Current market utilization rate (0–1). Populated for Morpho markets; undefined for Aave. */
   utilizationRate?: number;

--- a/packages/server/test/morpho.test.ts
+++ b/packages/server/test/morpho.test.ts
@@ -63,6 +63,7 @@ function samplePosition(overrides?: Partial<RawMorphoMarketPosition>): RawMorpho
     },
     borrowAssets: '500000000', // 500 USDC (6 decimals)
     borrowAssetsUsd: 500,
+    accruedBorrowInterestUsd: 12.34,
     supplyAssets: '0',
     supplyAssetsUsd: 0,
     collateral: '1000000000000000000', // 1 WETH (18 decimals)
@@ -178,6 +179,7 @@ describe('fetchFromMorphoApi', () => {
     assert.equal(loan.morphoMarketParams.irm, '0x0000000000000000000000000000000000000002');
     assert.equal(loan.morphoMarketParams.lltv, '860000000000000000');
     assert.equal(loan.marketSupplyApy, 0.0305);
+    assert.equal(loan.accruedBorrowInterestUsd, 12.34);
     assert.equal(callCount, 1);
   });
 
@@ -271,6 +273,7 @@ describe('fetchFromMorphoApi', () => {
       state: {
         borrowAssets: pos.borrowAssets!,
         borrowAssetsUsd: pos.borrowAssetsUsd!,
+        accruedBorrowInterestUsd: pos.accruedBorrowInterestUsd!,
         supplyAssets: pos.supplyAssets!,
         supplyAssetsUsd: pos.supplyAssetsUsd!,
         collateral: pos.collateral!,
@@ -293,6 +296,7 @@ describe('fetchFromMorphoApi', () => {
     assert.equal(loans[0].morphoMarketParams?.oracle, '0x0000000000000000000000000000000000000001');
     assert.equal(loans[0].borrowed[0].usdValue, 500);
     assert.equal(loans[0].supplied[0].usdValue, 3000);
+    assert.equal(loans[0].accruedBorrowInterestUsd, 12.34);
     assert.ok(queries.length >= 1);
     assert.doesNotMatch(queries[0]!, /\buniqueKey\b/);
     assert.doesNotMatch(queries[0]!, /\boracleAddress\b/);

--- a/src/components/dashboard/PositionTables.tsx
+++ b/src/components/dashboard/PositionTables.tsx
@@ -21,6 +21,7 @@ type LoanSortKey =
   | 'collateral'
   | 'borrowed'
   | 'debt'
+  | 'accruedBorrowInterest'
   | 'healthFactor'
   | 'rate'
   | 'ltv'
@@ -43,6 +44,12 @@ const loanSortColumns = [
   { key: 'collateral', label: 'Collateral', defaultDirection: 'asc' },
   { key: 'borrowed', label: 'Borrowed', defaultDirection: 'asc' },
   { key: 'debt', label: 'Debt', align: 'right', defaultDirection: 'desc' },
+  {
+    key: 'accruedBorrowInterest',
+    label: 'Accrued Int.',
+    align: 'right',
+    defaultDirection: 'desc',
+  },
   { key: 'healthFactor', label: 'HF', align: 'right', defaultDirection: 'asc' },
   { key: 'rate', label: 'Rate', align: 'right', defaultDirection: 'desc' },
   { key: 'ltv', label: 'LTV', align: 'right', defaultDirection: 'desc' },
@@ -61,6 +68,8 @@ function getLoanSortValue(row: LoanRow, key: LoanSortKey): string | number {
       return loan.borrowed.map((asset) => asset.symbol).join(' + ');
     case 'debt':
       return metrics.debt;
+    case 'accruedBorrowInterest':
+      return row.loan.accruedBorrowInterestUsd ?? Number.NaN;
     case 'healthFactor':
       return metrics.healthFactor;
     case 'rate':
@@ -204,6 +213,11 @@ export function LoanPositionsTable({
                   <td className="px-4 py-3">{loan.borrowed.map((a) => a.symbol).join(' + ')}</td>
                   <td className="px-4 py-3 text-right font-semibold tabular-nums">
                     {fmtUSD(metrics.debt, 0)}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {loan.accruedBorrowInterestUsd == null
+                      ? '—'
+                      : fmtUSD(loan.accruedBorrowInterestUsd, 2)}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Badge variant={toBadgeVariant(healthLabel(metrics.healthFactor).tone)}>


### PR DESCRIPTION
### Motivation
- Provide an "Accrued Int." value in the dashboard loan table so borrowed positions that expose accrued interest (e.g. Morpho API) are visible alongside debt and risk metrics.

### Description
- Add optional `accruedBorrowInterestUsd?: number` to `LoanPosition` in `packages/aave-core/src/types.ts` to carry an upstream-provided accrued-interest USD value.
- Parse `accruedBorrowInterest` / `accruedBorrowInterestUsd` from Morpho GraphQL responses in `packages/aave-core/src/morpho.ts` and map the USD value into the constructed `LoanPosition` objects.
- Render a sortable `Accrued Int.` column in the loan positions table (`src/components/dashboard/PositionTables.tsx`) that shows `—` when the value is not available and sorts by the numeric USD value when present.
- Update tests and docs by extending `packages/server/test/morpho.test.ts` to assert parsing of the new field and by adding notes to `README.md` and `CLAUDE.md` about the new column and its API-dependent availability.

### Testing
- Ran formatting with `yarn format` and the code was formatted successfully.
- Ran type checks with `yarn typecheck` and ESLint via `yarn lint` with no errors.
- Executed Morpho unit tests with `yarn workspace @aave-monitor/server tsx --tsconfig tsconfig.test.json --test test/morpho.test.ts`, and all tests passed (17 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe75fefe0832c9af2df001e09ebcc)