### PR TITLE
feat: track borrow rate history server-side in SQLite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Backend server notes:
 - Backend Graph/CoinGecko keys are read from `VITE_THE_GRAPH_API_KEY` and `VITE_COINGECKO_API_KEY` (legacy non-`VITE_` names still work as fallback).
 - `POST /api/status/refresh` forces an immediate monitor recomputation and returns fresh `/api/status` payload.
 - `GET /api/reserves/telemetry?market=<market>&asset=<address>&symbol=<optional>` returns live on-chain reserve utilization and interest-rate-strategy parameters for the selected borrowed asset.
+- `GET /api/rates/history?wallet=<address>&loanId=<id>&from=<epochMs>&to=<epochMs>` returns historical borrow/supply rate samples for a given wallet and loan, stored in SQLite (`packages/server/data/rates.db`). Rates are recorded every 15 minutes during the monitor poll cycle with 180-day retention.
 - Telegram `/status` includes portfolio average health factor, Net APY, total collateral, total debt, portfolio borrow power used, and repay coverage (USD and %) alongside per-loan health factors. Telegram alerts include per-asset liquidation prices for each collateral asset, and multiple loan alerts for the same wallet are grouped into a single Telegram message per poll.
 - Loan-specific Telegram messages now also include the current weighted borrow rate percentage for the loan, covering `/status`, zone alerts, reminders, recoveries, all-clear messages, and watchdog notifications.
 - Telegram per-loan `Adjusted HF` in server status/alerts is the projected post-rescue HF after repaying with the wallet's full balance of matching debt tokens, capped by that loan's outstanding debt.
@@ -82,7 +83,7 @@ Backend server notes:
 Frontend notes:
 
 - `src/App.tsx` stores the last successfully loaded wallet under `localStorage['aave-monitor:last-wallet']`.
-- `src/App.tsx` also stores borrow APR history per market/asset in browser `localStorage` under the `aave-monitor:borrow-apr-history:*` prefix.
+- Borrow APR history is tracked server-side in SQLite (`packages/server/data/rates.db`) by the monitor poll loop and served via `/api/rates/history`. The frontend fetches from the API and falls back to browser `localStorage` (`aave-monitor:borrow-apr-history:*`) when the backend has no data yet.
 - `src/components/dashboard/SummaryCards.tsx` stores the top-level privacy toggle under `localStorage['aave-monitor:hide-top-level-values']` and uses it to blur `Total Debt` and `Total Assets`.
 - On page load, wallet resolution order is: query string (`wallet`, `address`, `walletAddress`) first, then saved local storage wallet.
 - Portfolio summary math is centralized in `computePortfolioSummary()` in `packages/aave-core/src/metrics.ts`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A React + Vite dashboard that auto-loads Aave loans, Morpho Blue market position
   - Loan table `Accrued Int.` column for borrowed positions when provided by the upstream protocol API (currently populated for Morpho positions when available)
   - Separate Morpho vault table with deposited asset amount, USD value, net APY, and shares
   - Aave interest-rate model chart for the selected borrowed asset, including current utilization and the reserve kink
-  - Borrow APR history chart for the selected borrowed asset, built from locally stored reserve telemetry samples
+  - Borrow APR history chart for the selected borrowed asset, tracked server-side with 180-day retention
   - Repay coverage based on wallet balances that match borrowed assets
   - Monitoring checklist + sensitivity cards
 
@@ -220,12 +220,12 @@ The watchdog monitors loan health and can execute an atomic on-chain rescue when
 4. Token prices are fetched from CoinGecko for Aave assets, while Morpho positions use API-provided pricing or USD back-calculation for borrowed assets and vault deposits. Morpho market borrow/supply rates are aligned to Morpho's interface default 1-day average APY by preferring Morpho's `avgBorrowApy` / `avgSupplyApy` fields instead of the instantaneous spot rate.
 5. Portfolio-level aggregate metrics are computed across all active positions, with loan-risk metrics kept separate from supply-only vault assets.
 6. Detailed risk metrics are computed and rendered for the selected loan, while Morpho vaults render in a separate table.
-7. When the API server is available, the dashboard also reads on-chain reserve telemetry for the selected borrowed asset and stores periodic borrow APR samples in browser `localStorage` to build the history chart over time.
+7. The backend monitor records borrow/supply rate samples to a SQLite database (`packages/server/data/rates.db`) every 15 minutes during its poll cycle. The dashboard fetches rate history from the `/api/rates/history` endpoint; it falls back to browser `localStorage` when the backend has no data yet.
 
 ## Limitations
 
 - Liquidation price is shown as a primary-collateral approximation for multi-collateral positions.
 - Coverage depends on the supported market list and indexer availability.
 - Metrics are simplified monitoring estimates, not a substitute for protocol-native risk engines.
-- Borrow APR history is forward-looking: it is sampled from each dashboard refresh and stored in the current browser, so newly visited assets start with an empty chart.
+- Borrow APR history is forward-looking: the server begins recording from the first poll after deployment, so newly monitored wallets start with an empty chart.
 - GitHub Pages deployments require proper repository secrets if API keys are needed at build time.

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:25-alpine AS builder
 
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
+
 COPY package.json yarn.lock ./
 COPY packages/aave-core/package.json packages/aave-core/
 COPY packages/server/package.json packages/server/

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@aave-monitor/core": "*",
     "@bgd-labs/aave-address-book": "^4.44.22",
+    "better-sqlite3": "^12.9.0",
     "date-fns": "^4.1.0",
     "ethers": "^6.16.0",
     "express": "^5.1.0",
@@ -21,6 +22,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.0",
     "tsx": "^4.19.0",
     "typescript": "~5.9.2"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,6 +16,7 @@ import { logger } from './logger.js';
 import { fetchReserveTelemetry } from './reserveTelemetry.js';
 import { parseConfigBody } from './configSchema.js';
 import { formatStatusMessage } from './statusMessage.js';
+import { RateHistoryDb } from './rateHistoryDb.js';
 
 const tokenBalanceRequestSchema = z.object({
   tokens: z.array(
@@ -30,6 +31,13 @@ const reserveTelemetryQuerySchema = z.object({
   market: z.string().min(1),
   asset: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
   symbol: z.string().optional(),
+});
+
+const rateHistoryQuerySchema = z.object({
+  wallet: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  loanId: z.string().min(1),
+  from: z.coerce.number().int().optional(),
+  to: z.coerce.number().int().optional(),
 });
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,6 +58,7 @@ const WATCHDOG_EXECUTOR_PRIVATE_KEY =
 const configPath = join(__dirname, '..', 'data', 'config.json');
 const storage = new ConfigStorage(configPath);
 const telegram = new TelegramClient(TELEGRAM_BOT_TOKEN);
+const rateHistoryDb = new RateHistoryDb(join(__dirname, '..', 'data', 'rates.db'));
 const monitor = new Monitor(
   telegram,
   () => storage.get(),
@@ -57,6 +66,7 @@ const monitor = new Monitor(
   COINGECKO_API_KEY,
   RPC_URL,
   WATCHDOG_EXECUTOR_PRIVATE_KEY,
+  rateHistoryDb,
 );
 
 const TELEGRAM_BOT_COMMANDS: TelegramBotCommand[] = [
@@ -244,6 +254,17 @@ app.get('/api/reserves/telemetry', async (req, res) => {
     const message = error instanceof Error ? error.message : 'Failed to fetch reserve telemetry';
     res.status(502).json({ error: message });
   }
+});
+
+app.get('/api/rates/history', (req, res) => {
+  const parsed = rateHistoryQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid wallet address or loanId' });
+    return;
+  }
+  const { wallet, loanId, from, to } = parsed.data;
+  const samples = rateHistoryDb.querySamples(wallet, loanId, from, to);
+  res.json({ samples });
 });
 
 app.get('/api/health', (_req, res) => {

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -165,7 +165,11 @@ export class Monitor {
       for (const wallet of enabledWallets) {
         await this.checkWallet(wallet.address, wallet.label, config, chatId);
       }
-      this.rateHistoryDb?.prune(180 * 24 * 60 * 60 * 1000);
+      try {
+        this.rateHistoryDb?.prune(180 * 24 * 60 * 60 * 1000);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to prune rate history');
+      }
       this.lastPollAt = Date.now();
       this.lastError = null;
     } catch (error) {
@@ -244,19 +248,24 @@ export class Monitor {
       const stateKey = `${address}-${loan.id}`;
       activeStateKeys.add(stateKey);
 
-      // Record rate sample (throttled to 15-minute intervals)
+      // Record rate sample (throttled to 15-minute intervals).
+      // Guarded so DB failures never interrupt core health monitoring.
       if (this.rateHistoryDb) {
         const lastTs = this.lastSampleAt.get(stateKey) ?? 0;
         if (now - lastTs >= 15 * 60 * 1000) {
-          this.rateHistoryDb.appendSample(
-            address,
-            loan.id,
-            loan.marketName,
-            now,
-            metrics.rBorrow,
-            metrics.rSupply,
-          );
-          this.lastSampleAt.set(stateKey, now);
+          try {
+            this.rateHistoryDb.appendSample(
+              address,
+              loan.id,
+              loan.marketName,
+              now,
+              metrics.rBorrow,
+              metrics.rSupply,
+            );
+            this.lastSampleAt.set(stateKey, now);
+          } catch (err) {
+            logger.warn({ err, loan: loan.id }, 'Failed to record rate sample');
+          }
         }
       }
 

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -20,6 +20,7 @@ import type { TelegramClient } from './telegram.js';
 import { Watchdog, type WatchdogLogEntry } from './watchdog.js';
 import { logger } from './logger.js';
 import { computeRescueAdjustedHF } from './rescueMetrics.js';
+import type { RateHistoryDb } from './rateHistoryDb.js';
 
 export type LoanAlertState = {
   loanId: string;
@@ -66,6 +67,7 @@ export class Monitor {
   private lastPollAt: number | null = null;
   private lastError: string | null = null;
   private running = false;
+  private lastSampleAt = new Map<string, number>();
   readonly watchdog: Watchdog;
 
   constructor(
@@ -75,6 +77,7 @@ export class Monitor {
     private readonly coingeckoApiKey: string | undefined,
     private readonly rpcUrl: string,
     privateKey: string | undefined,
+    private readonly rateHistoryDb?: RateHistoryDb,
   ) {
     this.watchdog = new Watchdog(
       telegram,
@@ -162,6 +165,7 @@ export class Monitor {
       for (const wallet of enabledWallets) {
         await this.checkWallet(wallet.address, wallet.label, config, chatId);
       }
+      this.rateHistoryDb?.prune(180 * 24 * 60 * 60 * 1000);
       this.lastPollAt = Date.now();
       this.lastError = null;
     } catch (error) {
@@ -239,6 +243,22 @@ export class Monitor {
       const zone = classifyZone(metrics.healthFactor, this.hydrateZones(config.zones));
       const stateKey = `${address}-${loan.id}`;
       activeStateKeys.add(stateKey);
+
+      // Record rate sample (throttled to 15-minute intervals)
+      if (this.rateHistoryDb) {
+        const lastTs = this.lastSampleAt.get(stateKey) ?? 0;
+        if (now - lastTs >= 15 * 60 * 1000) {
+          this.rateHistoryDb.appendSample(
+            address,
+            loan.id,
+            loan.marketName,
+            now,
+            metrics.rBorrow,
+            metrics.rSupply,
+          );
+          this.lastSampleAt.set(stateKey, now);
+        }
+      }
 
       const collateralInfo = loan.supplied
         .map((c) => `${c.symbol}=$${c.usdPrice > 0 ? c.usdPrice : 'MISSING'}`)

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -10,6 +10,8 @@ export class RateHistoryDb {
   private db: Database.Database;
   private insertStmt: Database.Statement;
   private queryStmt: Database.Statement;
+  private queryFromStmt: Database.Statement;
+  private queryToStmt: Database.Statement;
   private queryRangeStmt: Database.Statement;
   private pruneStmt: Database.Statement;
 
@@ -27,15 +29,21 @@ export class RateHistoryDb {
         borrow_rate REAL    NOT NULL,
         supply_rate REAL    NOT NULL
       );
-      CREATE INDEX IF NOT EXISTS idx_samples_lookup
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_samples_unique
         ON rate_samples (wallet, loan_id, timestamp);
     `);
 
     this.insertStmt = this.db.prepare(
-      'INSERT INTO rate_samples (wallet, loan_id, market, timestamp, borrow_rate, supply_rate) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO rate_samples (wallet, loan_id, market, timestamp, borrow_rate, supply_rate) VALUES (?, ?, ?, ?, ?, ?)',
     );
     this.queryStmt = this.db.prepare(
       'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? ORDER BY timestamp ASC',
+    );
+    this.queryFromStmt = this.db.prepare(
+      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? ORDER BY timestamp ASC',
+    );
+    this.queryToStmt = this.db.prepare(
+      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp <= ? ORDER BY timestamp ASC',
     );
     this.queryRangeStmt = this.db.prepare(
       'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC',
@@ -55,19 +63,18 @@ export class RateHistoryDb {
   }
 
   querySamples(wallet: string, loanId: string, fromMs?: number, toMs?: number): RateSample[] {
+    type Row = { timestamp: number; borrow_rate: number; supply_rate: number };
     const w = wallet.toLowerCase();
-    const rows =
-      fromMs != null && toMs != null
-        ? (this.queryRangeStmt.all(w, loanId, fromMs, toMs) as Array<{
-            timestamp: number;
-            borrow_rate: number;
-            supply_rate: number;
-          }>)
-        : (this.queryStmt.all(w, loanId) as Array<{
-            timestamp: number;
-            borrow_rate: number;
-            supply_rate: number;
-          }>);
+    let rows: Row[];
+    if (fromMs != null && toMs != null) {
+      rows = this.queryRangeStmt.all(w, loanId, fromMs, toMs) as Row[];
+    } else if (fromMs != null) {
+      rows = this.queryFromStmt.all(w, loanId, fromMs) as Row[];
+    } else if (toMs != null) {
+      rows = this.queryToStmt.all(w, loanId, toMs) as Row[];
+    } else {
+      rows = this.queryStmt.all(w, loanId) as Row[];
+    }
     return rows.map((r) => ({
       timestamp: r.timestamp,
       borrowRate: r.borrow_rate,

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -1,0 +1,87 @@
+import Database from 'better-sqlite3';
+
+export type RateSample = {
+  timestamp: number; // epoch ms
+  borrowRate: number; // weighted decimal, e.g. 0.0325 = 3.25%
+  supplyRate: number;
+};
+
+export class RateHistoryDb {
+  private db: Database.Database;
+  private insertStmt: Database.Statement;
+  private queryStmt: Database.Statement;
+  private queryRangeStmt: Database.Statement;
+  private pruneStmt: Database.Statement;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS rate_samples (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        wallet      TEXT    NOT NULL,
+        loan_id     TEXT    NOT NULL,
+        market      TEXT    NOT NULL,
+        timestamp   INTEGER NOT NULL,
+        borrow_rate REAL    NOT NULL,
+        supply_rate REAL    NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_samples_lookup
+        ON rate_samples (wallet, loan_id, timestamp);
+    `);
+
+    this.insertStmt = this.db.prepare(
+      'INSERT INTO rate_samples (wallet, loan_id, market, timestamp, borrow_rate, supply_rate) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    this.queryStmt = this.db.prepare(
+      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? ORDER BY timestamp ASC',
+    );
+    this.queryRangeStmt = this.db.prepare(
+      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC',
+    );
+    this.pruneStmt = this.db.prepare('DELETE FROM rate_samples WHERE timestamp < ?');
+  }
+
+  appendSample(
+    wallet: string,
+    loanId: string,
+    market: string,
+    timestampMs: number,
+    borrowRate: number,
+    supplyRate: number,
+  ): void {
+    this.insertStmt.run(wallet.toLowerCase(), loanId, market, timestampMs, borrowRate, supplyRate);
+  }
+
+  querySamples(wallet: string, loanId: string, fromMs?: number, toMs?: number): RateSample[] {
+    const w = wallet.toLowerCase();
+    const rows =
+      fromMs != null && toMs != null
+        ? (this.queryRangeStmt.all(w, loanId, fromMs, toMs) as Array<{
+            timestamp: number;
+            borrow_rate: number;
+            supply_rate: number;
+          }>)
+        : (this.queryStmt.all(w, loanId) as Array<{
+            timestamp: number;
+            borrow_rate: number;
+            supply_rate: number;
+          }>);
+    return rows.map((r) => ({
+      timestamp: r.timestamp,
+      borrowRate: r.borrow_rate,
+      supplyRate: r.supply_rate,
+    }));
+  }
+
+  prune(maxAgeMs: number): number {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = this.pruneStmt.run(cutoff);
+    return result.changes;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/server/test/rate-history-db.test.ts
+++ b/packages/server/test/rate-history-db.test.ts
@@ -90,3 +90,44 @@ test('prune removes samples older than maxAge and keeps recent ones', () => {
   assert.equal(remaining.length, 2);
   db.close();
 });
+
+test('querySamples filters with from-only', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', 2000, 0.04, 0.02);
+  db.appendSample('0xabc', 'loan-1', 'market', 3000, 0.05, 0.03);
+
+  const samples = db.querySamples('0xabc', 'loan-1', 1500);
+  assert.equal(samples.length, 2);
+  assert.deepEqual(
+    samples.map((s) => s.timestamp),
+    [2000, 3000],
+  );
+  db.close();
+});
+
+test('querySamples filters with to-only', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', 2000, 0.04, 0.02);
+  db.appendSample('0xabc', 'loan-1', 'market', 3000, 0.05, 0.03);
+
+  const samples = db.querySamples('0xabc', 'loan-1', undefined, 2500);
+  assert.equal(samples.length, 2);
+  assert.deepEqual(
+    samples.map((s) => s.timestamp),
+    [1000, 2000],
+  );
+  db.close();
+});
+
+test('duplicate samples with same wallet/loan/timestamp are silently ignored', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.05, 0.02);
+
+  const samples = db.querySamples('0xabc', 'loan-1');
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].borrowRate, 0.03);
+  db.close();
+});

--- a/packages/server/test/rate-history-db.test.ts
+++ b/packages/server/test/rate-history-db.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RateHistoryDb } from '../src/rateHistoryDb.js';
+
+function createDb(): RateHistoryDb {
+  return new RateHistoryDb(':memory:');
+}
+
+test('appendSample inserts and querySamples returns it', () => {
+  const db = createDb();
+  db.appendSample('0xABC', 'loan-1', 'proto_mainnet_v3', 1000, 0.035, 0.02);
+
+  const samples = db.querySamples('0xABC', 'loan-1');
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].timestamp, 1000);
+  assert.equal(samples[0].borrowRate, 0.035);
+  assert.equal(samples[0].supplyRate, 0.02);
+  db.close();
+});
+
+test('wallet addresses are normalized to lowercase', () => {
+  const db = createDb();
+  db.appendSample('0xABCDEF', 'loan-1', 'market', 1000, 0.03, 0.01);
+
+  const samples = db.querySamples('0xAbCdEf', 'loan-1');
+  assert.equal(samples.length, 1);
+  db.close();
+});
+
+test('querySamples returns empty array for non-existent keys', () => {
+  const db = createDb();
+  const samples = db.querySamples('0xNONE', 'loan-99');
+  assert.deepEqual(samples, []);
+  db.close();
+});
+
+test('querySamples filters by from/to range', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', 2000, 0.04, 0.02);
+  db.appendSample('0xabc', 'loan-1', 'market', 3000, 0.05, 0.03);
+
+  const samples = db.querySamples('0xabc', 'loan-1', 1500, 2500);
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].timestamp, 2000);
+  db.close();
+});
+
+test('querySamples returns results sorted by timestamp', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 3000, 0.05, 0.03);
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', 2000, 0.04, 0.02);
+
+  const samples = db.querySamples('0xabc', 'loan-1');
+  assert.deepEqual(
+    samples.map((s) => s.timestamp),
+    [1000, 2000, 3000],
+  );
+  db.close();
+});
+
+test('multiple loans for same wallet are stored independently', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market-a', 1000, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-2', 'market-b', 1000, 0.05, 0.02);
+
+  const loan1 = db.querySamples('0xabc', 'loan-1');
+  const loan2 = db.querySamples('0xabc', 'loan-2');
+  assert.equal(loan1.length, 1);
+  assert.equal(loan2.length, 1);
+  assert.equal(loan1[0].borrowRate, 0.03);
+  assert.equal(loan2[0].borrowRate, 0.05);
+  db.close();
+});
+
+test('prune removes samples older than maxAge and keeps recent ones', () => {
+  const db = createDb();
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+
+  db.appendSample('0xabc', 'loan-1', 'market', now - 10 * oneDay, 0.03, 0.01);
+  db.appendSample('0xabc', 'loan-1', 'market', now - 5 * oneDay, 0.04, 0.02);
+  db.appendSample('0xabc', 'loan-1', 'market', now - 1 * oneDay, 0.05, 0.03);
+
+  const deleted = db.prune(7 * oneDay);
+  assert.equal(deleted, 1);
+
+  const remaining = db.querySamples('0xabc', 'loan-1');
+  assert.equal(remaining.length, 2);
+  db.close();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -193,8 +193,10 @@ export default function App() {
     setSelectedReserveTelemetry(null);
     setReserveTelemetryError('');
 
-    // Fetch rate history from backend, fall back to localStorage if unavailable
-    void fetchBorrowRateHistory(wallet, selectedLoan.id).then((apiSamples) => {
+    // Fetch rate history from backend, fall back to localStorage if unavailable.
+    // Use the resolved wallet from the loaded result, not the editable input field.
+    const resolvedWallet = result?.wallet ?? wallet.trim();
+    void fetchBorrowRateHistory(resolvedWallet, selectedLoan.id).then((apiSamples) => {
       if (cancelled) return;
       if (apiSamples.length > 0) {
         setBorrowRateHistory(apiSamples);
@@ -229,7 +231,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [result?.lastUpdated, selectedLoan?.marketName, selectedLoan, wallet]);
+  }, [result?.lastUpdated, result?.wallet, selectedLoan?.marketName, selectedLoan, wallet]);
 
   const handleFetch = async (event: FormEvent) => {
     event.preventDefault();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,13 +10,12 @@ import {
   type FetchState,
   type ReserveTelemetry,
 } from '@aave-monitor/core';
-import { fetchReserveTelemetry, fetchWalletAssetBalances } from './api/aaveMonitor';
 import {
-  appendBorrowRateSample,
-  buildBorrowRateHistoryKey,
-  readBorrowRateHistory,
-  writeBorrowRateHistory,
-} from './lib/borrowRateHistory';
+  fetchBorrowRateHistory,
+  fetchReserveTelemetry,
+  fetchWalletAssetBalances,
+} from './api/aaveMonitor';
+import { readBorrowRateHistory, buildBorrowRateHistoryKey } from './lib/borrowRateHistory';
 import { type BorrowRateSample } from './components/ReserveCharts';
 import { ServerSettings } from './components/ServerSettings';
 import { ToastProvider, ToastViewport } from './components/ui/toast';
@@ -152,7 +151,7 @@ export default function App() {
     if (!ETHEREUM_ADDRESS_REGEX.test(initialWallet)) return;
 
     hasAutoFetchedInitialWallet.current = true;
-    void fetchLoans(initialWallet);
+    void fetchLoans(initialWallet); // eslint-disable-line react-hooks/set-state-in-effect -- fetch-on-mount
   }, [wallet, fetchLoans]);
 
   useEffect(() => {
@@ -180,7 +179,7 @@ export default function App() {
 
   useEffect(() => {
     if (!selectedLoan || selectedLoan.borrowed.length === 0) {
-      setSelectedReserveTelemetry(null);
+      setSelectedReserveTelemetry(null); // eslint-disable-line react-hooks/set-state-in-effect -- resetting state on dependency change
       setReserveTelemetryError('');
       setBorrowRateHistory([]);
       return;
@@ -189,43 +188,33 @@ export default function App() {
     const primaryBorrow = selectedLoan.borrowed.reduce((max, borrowed) =>
       borrowed.usdValue > max.usdValue ? borrowed : max,
     );
-    const storageKey = buildBorrowRateHistoryKey(selectedLoan.marketName, primaryBorrow.address);
-    setBorrowRateHistory(readBorrowRateHistory(storageKey));
 
     let cancelled = false;
     setSelectedReserveTelemetry(null);
     setReserveTelemetryError('');
 
+    // Fetch rate history from backend, fall back to localStorage if unavailable
+    void fetchBorrowRateHistory(wallet, selectedLoan.id).then((apiSamples) => {
+      if (cancelled) return;
+      if (apiSamples.length > 0) {
+        setBorrowRateHistory(apiSamples);
+      } else {
+        const storageKey = buildBorrowRateHistoryKey(
+          selectedLoan.marketName,
+          primaryBorrow.address,
+        );
+        setBorrowRateHistory(readBorrowRateHistory(storageKey));
+      }
+    });
+
     if (selectedLoan.marketName.startsWith('morpho_')) {
-      // Morpho data comes from the API response — append a sample using the available values.
-      const morphoRate = primaryBorrow.borrowRate;
-      const morphoUtilization = selectedLoan.utilizationRate ?? 0;
-      setBorrowRateHistory((currentSamples) => {
-        const nextSamples = appendBorrowRateSample(currentSamples, {
-          timestamp: result?.lastUpdated ?? new Date().toISOString(),
-          variableBorrowRate: morphoRate,
-          utilizationRate: morphoUtilization,
-        });
-        writeBorrowRateHistory(storageKey, nextSamples);
-        return nextSamples;
-      });
       return;
     }
 
     void fetchReserveTelemetry(selectedLoan.marketName, primaryBorrow.address, primaryBorrow.symbol)
       .then((telemetry) => {
         if (cancelled) return;
-
         setSelectedReserveTelemetry(telemetry);
-        setBorrowRateHistory((currentSamples) => {
-          const nextSamples = appendBorrowRateSample(currentSamples, {
-            timestamp: telemetry.lastUpdateTimestamp,
-            variableBorrowRate: telemetry.variableBorrowRate,
-            utilizationRate: telemetry.utilizationRate,
-          });
-          writeBorrowRateHistory(storageKey, nextSamples);
-          return nextSamples;
-        });
       })
       .catch((telemetryError: unknown) => {
         if (cancelled) return;
@@ -240,7 +229,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [result?.lastUpdated, selectedLoan?.marketName, selectedLoan]);
+  }, [result?.lastUpdated, selectedLoan?.marketName, selectedLoan, wallet]);
 
   const handleFetch = async (event: FormEvent) => {
     event.preventDefault();

--- a/src/api/aaveMonitor.ts
+++ b/src/api/aaveMonitor.ts
@@ -1,4 +1,30 @@
 import { type AssetPosition, type ReserveTelemetry } from '@aave-monitor/core';
+import type { BorrowRateSample } from '../components/ReserveCharts';
+
+type RateHistoryResponse = {
+  samples: Array<{ timestamp: number; borrowRate: number; supplyRate: number }>;
+};
+
+export async function fetchBorrowRateHistory(
+  wallet: string,
+  loanId: string,
+  fromMs?: number,
+  toMs?: number,
+): Promise<BorrowRateSample[]> {
+  const params = new URLSearchParams({ wallet, loanId });
+  if (fromMs != null) params.set('from', String(fromMs));
+  if (toMs != null) params.set('to', String(toMs));
+
+  const res = await fetch(`/api/rates/history?${params.toString()}`);
+  if (!res.ok) return [];
+
+  const data = (await res.json()) as RateHistoryResponse;
+  return data.samples.map((s) => ({
+    timestamp: new Date(s.timestamp).toISOString(),
+    variableBorrowRate: s.borrowRate,
+    utilizationRate: 0,
+  }));
+}
 
 export async function fetchWalletAssetBalances(
   wallet: string,

--- a/src/components/ReserveCharts.tsx
+++ b/src/components/ReserveCharts.tsx
@@ -479,7 +479,7 @@ export function BorrowRateHistoryCard({
         <div>
           <CardTitle>Borrow APR History</CardTitle>
           <p className="mt-1 text-sm text-muted-foreground">
-            Sampled from reserve telemetry on each refresh and stored locally in this browser.
+            Sampled from reserve telemetry by the server and tracked over time.
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-1">

--- a/src/components/ServerSettings.tsx
+++ b/src/components/ServerSettings.tsx
@@ -196,7 +196,7 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
   }, []);
 
   useEffect(() => {
-    void fetchConfig();
+    void fetchConfig(); // eslint-disable-line react-hooks/set-state-in-effect -- fetch-on-mount
   }, [fetchConfig]);
 
   const saveConfig = async (updated: AlertConfig) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,10 +1023,10 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-baseline-browser-mapping@^2.9.0:
-  version "2.10.10"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz#e74bd066724c1d8d7d8ea75fc3be25389a7a5c56"
-  integrity sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==
+baseline-browser-mapping@^2.10.12:
+  version "2.10.19"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
+  integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
 
 body-parser@^2.2.1:
   version "2.2.2"
@@ -1051,15 +1051,15 @@ brace-expansion@^5.0.5:
     balanced-match "^4.0.2"
 
 browserslist@^4.24.0:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
-  integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
   dependencies:
-    baseline-browser-mapping "^2.9.0"
-    caniuse-lite "^1.0.30001759"
-    electron-to-chromium "^1.5.263"
-    node-releases "^2.0.27"
-    update-browserslist-db "^1.2.0"
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
 
 bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
@@ -1082,10 +1082,10 @@ call-bound@^1.0.2:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
-caniuse-lite@^1.0.30001759:
-  version "1.0.30001781"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz#344b47c03eb8168b79c3c158b872bcfbdd02a400"
-  integrity sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001788"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
+  integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
 
 class-variance-authority@^0.7.1:
   version "0.7.1"
@@ -1179,10 +1179,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.5.263:
-  version "1.5.325"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz#c2b3d510435a2b65dd65e891dde7eac0362edfb7"
-  integrity sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==
+electron-to-chromium@^1.5.328:
+  version "1.5.339"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz#d797bf5f222a7f6241a42b43a97bf52ff43947f1"
+  integrity sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==
 
 encodeurl@^2.0.0:
   version "2.0.0"
@@ -1267,9 +1267,9 @@ eslint-config-prettier@^10.1.8:
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
 
 eslint-plugin-react-hooks@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz#66e258db58ece50723ef20cc159f8aa908219169"
-  integrity sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0.tgz#46f19a653041fab6fc4b6d66873cd387f779e6ad"
+  integrity sha512-LDicyhrRFrIaheDYryeM2W8gWyZXnAs4zIr2WVPiOSeTmIu2RjR4x/9N0xLaRWZ+9hssBDGo3AadcohuzAvSvg==
   dependencies:
     "@babel/core" "^7.24.4"
     "@babel/parser" "^7.24.4"
@@ -1854,10 +1854,10 @@ negotiator@^1.0.0:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
-node-releases@^2.0.27:
-  version "2.0.36"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.36.tgz#99fd6552aaeda9e17c4713b57a63964a2e325e9d"
-  integrity sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==
+node-releases@^2.0.36:
+  version "2.0.37"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.37.tgz#9bd4f10b77ba39c2b9402d4e8399c482a797f671"
+  integrity sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==
 
 object-inspect@^1.13.3:
   version "1.13.4"
@@ -1983,9 +1983,9 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^3.6.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.2.tgz#4f52e502193c9aa5b384c3d00852003e551bbd9f"
-  integrity sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
+  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
 
 process-warning@^5.0.0:
   version "5.0.0"
@@ -2312,9 +2312,9 @@ typescript@~5.9.2:
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 typescript@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.2.tgz#0b1bfb15f68c64b97032f3d78abbf98bdbba501f"
-  integrity sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 undici-types@~6.19.2:
   version "6.19.8"
@@ -2336,7 +2336,7 @@ unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.2.0:
+update-browserslist-db@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/better-sqlite3@^7.6.13":
+  version "7.6.13"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.6"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
@@ -1023,10 +1030,39 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 baseline-browser-mapping@^2.10.12:
   version "2.10.19"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
   integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
+
+better-sqlite3@^12.9.0:
+  version "12.9.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.9.0.tgz#32498c99ba3fb36f604fbb5c70667c5f68c00414"
+  integrity sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 body-parser@^2.2.1:
   version "2.2.2"
@@ -1061,6 +1097,14 @@ browserslist@^4.24.0:
     node-releases "^2.0.36"
     update-browserslist-db "^1.2.3"
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -1086,6 +1130,11 @@ caniuse-lite@^1.0.30001782:
   version "1.0.30001788"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
   integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 class-variance-authority@^0.7.1:
   version "0.7.1"
@@ -1150,6 +1199,18 @@ debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
   dependencies:
     ms "^2.1.3"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -1160,7 +1221,7 @@ depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-detect-libc@^2.0.3:
+detect-libc@^2.0.0, detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -1188,6 +1249,13 @@ encodeurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.19.0:
   version "5.20.1"
@@ -1389,6 +1457,11 @@ ethers@^6.16.0:
     tslib "2.7.0"
     ws "8.17.1"
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 express@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
@@ -1450,6 +1523,11 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 finalhandler@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
@@ -1492,6 +1570,11 @@ fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fsevents@~2.3.3:
   version "2.3.3"
@@ -1538,6 +1621,11 @@ get-tsconfig@^4.7.5:
   integrity sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==
   dependencies:
     resolve-pkg-maps "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@^6.0.2:
   version "6.0.2"
@@ -1603,6 +1691,11 @@ iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -1618,10 +1711,15 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inherits@~2.0.4:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -1827,12 +1925,27 @@ mime-types@^3.0.0, mime-types@^3.0.2:
   dependencies:
     mime-db "^1.54.0"
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@^10.2.2, minimatch@^10.2.4:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
   dependencies:
     brace-expansion "^5.0.5"
+
+minimist@^1.2.0, minimist@^1.2.3:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -1844,6 +1957,11 @@ nanoid@^3.3.11:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -1853,6 +1971,13 @@ negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
+node-abi@^3.3.0:
+  version "3.89.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.89.0.tgz#eea98bf89d4534743bbbf2defa9f4f9bd3bdccfd"
+  integrity sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==
+  dependencies:
+    semver "^7.3.5"
 
 node-releases@^2.0.36:
   version "2.0.37"
@@ -1876,7 +2001,7 @@ on-finished@^2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.4.0:
+once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1977,6 +2102,24 @@ postcss@^8.5.8:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+prebuild-install@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -1999,6 +2142,14 @@ proxy-addr@^2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+pump@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
+  integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -2032,6 +2183,16 @@ raw-body@^3.0.1:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-dom@^19.0.0:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
@@ -2043,6 +2204,15 @@ react@^19.0.0:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
   integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 real-require@^0.2.0:
   version "0.2.0"
@@ -2089,6 +2259,11 @@ router@^2.2.0:
     parseurl "^1.3.3"
     path-to-regexp "^8.0.0"
 
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-stable-stringify@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
@@ -2109,7 +2284,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.7.3:
+semver@^7.3.5, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -2198,6 +2373,20 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 sonic-boom@^4.0.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.1.tgz#28598250df4899c0ac572d7e2f0460690ba6a030"
@@ -2220,6 +2409,18 @@ statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
 tailwind-merge@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-3.5.0.tgz#06502f4496ba15151445d97d916a26564d50d1ca"
@@ -2234,6 +2435,27 @@ tapable@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.2.tgz#86755feabad08d82a26b891db044808c6ad00f15"
   integrity sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==
+
+tar-fs@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 thread-stream@^4.0.0:
   version "4.0.0"
@@ -2279,6 +2501,13 @@ tsx@^4.19.0:
     get-tsconfig "^4.7.5"
   optionalDependencies:
     fsevents "~2.3.3"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2350,6 +2579,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 vary@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

- Adds `RateHistoryDb` class backed by `better-sqlite3` to persist borrow/supply rate samples in `packages/server/data/rates.db`
- Records weighted rates every 15 minutes during the existing monitor poll cycle (no separate polling)
- Exposes `GET /api/rates/history?wallet=...&loanId=...&from=...&to=...` endpoint
- Frontend fetches rate history from the API with localStorage fallback for migration
- 180-day automatic retention with pruning each poll cycle

## Test plan

- [x] All 82 existing tests pass, plus 7 new `rate-history-db.test.ts` tests
- [x] Lint and format clean
- [ ] Deploy and verify `data/rates.db` is created after first poll cycle
- [ ] `curl /api/rates/history?wallet=...&loanId=...` returns samples after 1-2 poll cycles
- [ ] Dashboard borrow APR history chart loads from API
- [ ] Docker build succeeds (native addon compiles on Alpine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)