### PR TITLE
feat: utilization-based Telegram alerts

### DIFF
--- a/packages/aave-core/src/constants.ts
+++ b/packages/aave-core/src/constants.ts
@@ -1,4 +1,4 @@
-import type { AaveMarket, PollingConfig, WatchdogConfig } from './types.js';
+import type { AaveMarket, PollingConfig, UtilizationConfig, WatchdogConfig } from './types.js';
 
 export const AAVE_MARKETS: readonly AaveMarket[] = [
   {
@@ -81,6 +81,12 @@ export const DEFAULT_POLLING_CONFIG: PollingConfig = {
   intervalMs: 5 * 60 * 1000,
   debounceChecks: 2,
   reminderIntervalMs: 30 * 60 * 1000,
+  cooldownMs: 30 * 60 * 1000,
+};
+
+export const DEFAULT_UTILIZATION_CONFIG: UtilizationConfig = {
+  enabled: true,
+  defaultThreshold: 0.9,
   cooldownMs: 30 * 60 * 1000,
 };
 

--- a/packages/aave-core/src/index.ts
+++ b/packages/aave-core/src/index.ts
@@ -15,6 +15,7 @@ export type {
   RawUserReserve,
   RawUserReserveWithMarket,
   ReserveTelemetry,
+  UtilizationConfig,
   WatchdogConfig,
 } from './types.js';
 
@@ -22,6 +23,7 @@ export {
   AAVE_MARKETS,
   COINGECKO_IDS_BY_SYMBOL,
   DEFAULT_POLLING_CONFIG,
+  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   ETHEREUM_ADDRESS_REGEX,
   STABLECOIN_CONTRACTS,

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -197,3 +197,11 @@ export type InterestRateCurvePoint = {
   utilizationRate: number;
   variableBorrowRate: number;
 };
+
+export type UtilizationConfig = {
+  enabled: boolean;
+  /** Default trigger threshold (0–1). Used when on-chain optimalUsageRatio unavailable. */
+  defaultThreshold: number;
+  /** Cooldown between alerts for same asset (ms). */
+  cooldownMs: number;
+};

--- a/packages/server/src/configSchema.ts
+++ b/packages/server/src/configSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { UtilizationConfig } from '@aave-monitor/core';
 import type { AlertConfig, WatchdogConfig } from './storage.js';
 
 const partialWatchdogConfigSchema = z
@@ -56,11 +57,19 @@ export const partialAlertConfigSchema = z
       }),
     ),
     watchdog: partialWatchdogConfigSchema,
+    utilization: z
+      .object({
+        enabled: z.boolean(),
+        defaultThreshold: z.number().min(0).max(1),
+        cooldownMs: z.number().positive(),
+      })
+      .partial(),
   })
   .partial();
 
-export type ConfigUpdate = Partial<Omit<AlertConfig, 'watchdog'>> & {
+export type ConfigUpdate = Partial<Omit<AlertConfig, 'watchdog' | 'utilization'>> & {
   watchdog?: Partial<WatchdogConfig>;
+  utilization?: Partial<UtilizationConfig>;
 };
 
 export function parseConfigBody(body: unknown): { data: ConfigUpdate } | { error: string } {

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -1,6 +1,8 @@
 import {
   type AssetLiquidation,
   type AssetPosition,
+  type LoanPosition,
+  type ReserveTelemetry,
   type Zone,
   type ZoneName,
   classifyZone,
@@ -20,6 +22,7 @@ import type { TelegramClient } from './telegram.js';
 import { Watchdog, type WatchdogLogEntry } from './watchdog.js';
 import { logger } from './logger.js';
 import { computeRescueAdjustedHF } from './rescueMetrics.js';
+import { fetchReserveTelemetry } from './reserveTelemetry.js';
 import type { RateHistoryDb } from './rateHistoryDb.js';
 
 export type LoanAlertState = {
@@ -41,9 +44,26 @@ export type LoanAlertState = {
   stuckSince: number | null;
 };
 
+export type UtilizationAlertState = {
+  wallet: string;
+  loanId: string;
+  marketName: string;
+  assetAddress: string;
+  assetSymbol: string;
+  /** Whether we have already sent an "exceeded" alert */
+  alerted: boolean;
+  /** Timestamp of last utilization alert sent */
+  lastNotifiedAt: number;
+  /** Last observed utilization rate (0–1) */
+  lastUtilization: number;
+  /** The threshold that was used (from on-chain optimalUsageRatio or config default) */
+  threshold: number;
+};
+
 export type MonitorStatus = {
   running: boolean;
   states: LoanAlertState[];
+  utilizationStates: UtilizationAlertState[];
   totalWalletBorrowedAssetUsd: number;
   lastPollAt: number | null;
   lastError: string | null;
@@ -51,7 +71,13 @@ export type MonitorStatus = {
 };
 
 type WalletNotification = {
-  kind: 'transition' | 'recovery' | 'all-clear' | 'reminder';
+  kind:
+    | 'transition'
+    | 'recovery'
+    | 'all-clear'
+    | 'reminder'
+    | 'utilization-high'
+    | 'utilization-normalized';
   message: string;
 };
 
@@ -62,6 +88,7 @@ type ReminderDigestEntry = {
 
 export class Monitor {
   private states = new Map<string, LoanAlertState>();
+  private utilizationStates = new Map<string, UtilizationAlertState>();
   private timerId: ReturnType<typeof setInterval> | null = null;
   private walletBorrowedAssetUsd = new Map<string, number>();
   private lastPollAt: number | null = null;
@@ -120,6 +147,7 @@ export class Monitor {
     return {
       running: this.running,
       states: Array.from(this.states.values()),
+      utilizationStates: Array.from(this.utilizationStates.values()),
       totalWalletBorrowedAssetUsd: Array.from(this.walletBorrowedAssetUsd.values()).reduce(
         (sum, value) => sum + value,
         0,
@@ -206,6 +234,39 @@ export class Monitor {
       return [];
     });
     const loans = [...buildLoanPositions(reserves, prices), ...morphoLoans];
+
+    // Fetch reserve telemetry for Aave loans when utilization alerts are enabled.
+    // Deduplicate by (marketName, assetAddress) to avoid redundant RPC calls.
+    const telemetryMap = new Map<string, ReserveTelemetry>();
+    if (config.utilization.enabled) {
+      const telemetryKeys = new Map<string, { marketName: string; assetAddress: string }>();
+      for (const loan of loans) {
+        if (loan.marketName.startsWith('morpho_')) continue;
+        for (const asset of loan.borrowed) {
+          const key = `${loan.marketName}:${asset.address.toLowerCase()}`;
+          if (!telemetryKeys.has(key)) {
+            telemetryKeys.set(key, {
+              marketName: loan.marketName,
+              assetAddress: asset.address,
+            });
+          }
+        }
+      }
+      const results = await Promise.allSettled(
+        Array.from(telemetryKeys.entries()).map(async ([key, { marketName, assetAddress }]) => {
+          const telemetry = await fetchReserveTelemetry(marketName, assetAddress, this.rpcUrl);
+          return { key, telemetry };
+        }),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          telemetryMap.set(result.value.key, result.value.telemetry);
+        } else {
+          logger.warn({ err: result.reason }, 'Failed to fetch reserve telemetry');
+        }
+      }
+    }
+
     const borrowedAssets = Array.from(
       new Map(
         loans
@@ -254,6 +315,7 @@ export class Monitor {
         const lastTs = this.lastSampleAt.get(stateKey) ?? 0;
         if (now - lastTs >= 15 * 60 * 1000) {
           try {
+            const utilizationForSample = this.resolveUtilization(loan, telemetryMap);
             this.rateHistoryDb.appendSample(
               address,
               loan.id,
@@ -261,6 +323,7 @@ export class Monitor {
               now,
               metrics.rBorrow,
               metrics.rSupply,
+              utilizationForSample,
             );
             this.lastSampleAt.set(stateKey, now);
           } catch (err) {
@@ -380,6 +443,105 @@ export class Monitor {
       }
     }
 
+    // Utilization alert pass — independent of HF zone transitions
+    const activeUtilKeys = new Set<string>();
+    if (config.utilization.enabled) {
+      for (const loan of loans) {
+        const metrics = computeLoanMetrics(loan);
+        for (const borrowedAsset of loan.borrowed) {
+          const assetAddr = borrowedAsset.address.toLowerCase();
+          let currentUtilization: number | undefined;
+          let threshold: number;
+
+          if (loan.marketName.startsWith('morpho_')) {
+            currentUtilization = loan.utilizationRate;
+            threshold = config.utilization.defaultThreshold;
+          } else {
+            const telKey = `${loan.marketName}:${assetAddr}`;
+            const telemetry = telemetryMap.get(telKey);
+            if (telemetry) {
+              currentUtilization = telemetry.utilizationRate;
+              threshold =
+                telemetry.optimalUsageRatio > 0
+                  ? telemetry.optimalUsageRatio
+                  : config.utilization.defaultThreshold;
+            } else {
+              continue;
+            }
+          }
+
+          if (currentUtilization == null) continue;
+
+          const utilKey = `${address}-${loan.id}-${assetAddr}`;
+          activeUtilKeys.add(utilKey);
+          const existingUtil = this.utilizationStates.get(utilKey);
+
+          if (!existingUtil) {
+            const isAbove = currentUtilization >= threshold;
+            this.utilizationStates.set(utilKey, {
+              wallet: address,
+              loanId: loan.id,
+              marketName: loan.marketName,
+              assetAddress: assetAddr,
+              assetSymbol: borrowedAsset.symbol,
+              alerted: isAbove,
+              lastNotifiedAt: isAbove ? now : 0,
+              lastUtilization: currentUtilization,
+              threshold,
+            });
+            if (isAbove && chatId) {
+              pendingNotifications.push({
+                kind: 'utilization-high',
+                message: this.formatUtilizationHigh(
+                  loan,
+                  borrowedAsset,
+                  currentUtilization,
+                  threshold,
+                  metrics,
+                ),
+              });
+            }
+            continue;
+          }
+
+          existingUtil.lastUtilization = currentUtilization;
+          existingUtil.threshold = threshold;
+
+          if (currentUtilization >= threshold && !existingUtil.alerted) {
+            existingUtil.alerted = true;
+            if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
+              pendingNotifications.push({
+                kind: 'utilization-high',
+                message: this.formatUtilizationHigh(
+                  loan,
+                  borrowedAsset,
+                  currentUtilization,
+                  threshold,
+                  metrics,
+                ),
+              });
+              existingUtil.lastNotifiedAt = now;
+            }
+          } else if (currentUtilization < threshold && existingUtil.alerted) {
+            existingUtil.alerted = false;
+            if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
+              pendingNotifications.push({
+                kind: 'utilization-normalized',
+                message: this.formatUtilizationNormalized(
+                  loan,
+                  borrowedAsset,
+                  currentUtilization,
+                  threshold,
+                  metrics,
+                ),
+              });
+              existingUtil.lastNotifiedAt = now;
+            }
+          }
+        }
+      }
+    }
+
     if (shouldSendReminderDigest) {
       for (const entry of reminderDigestEntries) {
         pendingNotifications.push({
@@ -408,6 +570,24 @@ export class Monitor {
         this.states.delete(stateKey);
       }
     }
+    for (const utilKey of Array.from(this.utilizationStates.keys())) {
+      if (utilKey.startsWith(walletPrefix) && !activeUtilKeys.has(utilKey)) {
+        this.utilizationStates.delete(utilKey);
+      }
+    }
+  }
+
+  private resolveUtilization(
+    loan: LoanPosition,
+    telemetryMap: Map<string, ReserveTelemetry>,
+  ): number | undefined {
+    if (loan.marketName.startsWith('morpho_')) {
+      return loan.utilizationRate;
+    }
+    const firstBorrowed = loan.borrowed[0];
+    if (!firstBorrowed) return undefined;
+    const telKey = `${loan.marketName}:${firstBorrowed.address.toLowerCase()}`;
+    return telemetryMap.get(telKey)?.utilizationRate;
   }
 
   private hydrateZones(configuredZones: AlertConfig['zones'] | undefined): Zone[] {
@@ -528,6 +708,50 @@ export class Monitor {
     ].join('\n');
   }
 
+  private formatUtilizationHigh(
+    loan: { marketName: string },
+    asset: { symbol: string },
+    utilization: number,
+    threshold: number,
+    metrics: { healthFactor: number; rBorrow: number },
+  ): string {
+    const utilPct = (utilization * 100).toFixed(1);
+    const threshPct = (threshold * 100).toFixed(1);
+    const hf = Number.isFinite(metrics.healthFactor) ? metrics.healthFactor.toFixed(2) : '\u221E';
+
+    return [
+      `\u26A0\uFE0F <b>HIGH UTILIZATION</b> \u2014 Rate Spike Risk`,
+      '',
+      `Market: ${loan.marketName} \u00B7 ${asset.symbol}`,
+      `Utilization: <b>${utilPct}%</b> (target: ${threshPct}%)`,
+      `HF: <b>${hf}</b> \u00B7 Borrow rate: <b>${this.formatBorrowRate(metrics.rBorrow)}</b>`,
+      '',
+      `Utilization above target \u2014 borrow rates may spike sharply.`,
+    ].join('\n');
+  }
+
+  private formatUtilizationNormalized(
+    loan: { marketName: string },
+    asset: { symbol: string },
+    utilization: number,
+    threshold: number,
+    metrics: { healthFactor: number; rBorrow: number },
+  ): string {
+    const utilPct = (utilization * 100).toFixed(1);
+    const threshPct = (threshold * 100).toFixed(1);
+    const hf = Number.isFinite(metrics.healthFactor) ? metrics.healthFactor.toFixed(2) : '\u221E';
+
+    return [
+      `\u2705 <b>UTILIZATION NORMALIZED</b>`,
+      '',
+      `Market: ${loan.marketName} \u00B7 ${asset.symbol}`,
+      `Utilization: <b>${utilPct}%</b> (target: ${threshPct}%)`,
+      `HF: <b>${hf}</b> \u00B7 Borrow rate: <b>${this.formatBorrowRate(metrics.rBorrow)}</b>`,
+      '',
+      `Utilization back below target \u2014 borrow rates returning to normal.`,
+    ].join('\n');
+  }
+
   private formatWalletNotification(
     address: string,
     label: string | undefined,
@@ -558,7 +782,11 @@ export class Monitor {
           ? 'Recovery'
           : kind === 'all-clear'
             ? 'All Clear'
-            : 'Reminder';
+            : kind === 'utilization-high'
+              ? 'High Utilization'
+              : kind === 'utilization-normalized'
+                ? 'Utilization Normalized'
+                : 'Reminder';
     return `${base} ${index + 1}`;
   }
 

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -182,6 +182,11 @@ export class Monitor {
         this.walletBorrowedAssetUsd.delete(existingAddress);
       }
     }
+    for (const [utilKey, utilState] of Array.from(this.utilizationStates.entries())) {
+      if (!enabledAddresses.has(utilState.wallet.toLowerCase())) {
+        this.utilizationStates.delete(utilKey);
+      }
+    }
 
     if (enabledWallets.length === 0) {
       this.lastPollAt = Date.now();
@@ -478,18 +483,19 @@ export class Monitor {
 
           if (!existingUtil) {
             const isAbove = currentUtilization >= threshold;
+            const sent = isAbove && chatId;
             this.utilizationStates.set(utilKey, {
               wallet: address,
               loanId: loan.id,
               marketName: loan.marketName,
               assetAddress: assetAddr,
               assetSymbol: borrowedAsset.symbol,
-              alerted: isAbove,
-              lastNotifiedAt: isAbove ? now : 0,
+              alerted: sent ? true : false,
+              lastNotifiedAt: sent ? now : 0,
               lastUtilization: currentUtilization,
               threshold,
             });
-            if (isAbove && chatId) {
+            if (sent) {
               pendingNotifications.push({
                 kind: 'utilization-high',
                 message: this.formatUtilizationHigh(
@@ -508,8 +514,9 @@ export class Monitor {
           existingUtil.threshold = threshold;
 
           if (currentUtilization >= threshold && !existingUtil.alerted) {
-            existingUtil.alerted = true;
             if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
+              existingUtil.alerted = true;
+              existingUtil.lastNotifiedAt = now;
               pendingNotifications.push({
                 kind: 'utilization-high',
                 message: this.formatUtilizationHigh(
@@ -520,11 +527,11 @@ export class Monitor {
                   metrics,
                 ),
               });
-              existingUtil.lastNotifiedAt = now;
             }
           } else if (currentUtilization < threshold && existingUtil.alerted) {
-            existingUtil.alerted = false;
             if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
+              existingUtil.alerted = false;
+              existingUtil.lastNotifiedAt = now;
               pendingNotifications.push({
                 kind: 'utilization-normalized',
                 message: this.formatUtilizationNormalized(
@@ -535,7 +542,6 @@ export class Monitor {
                   metrics,
                 ),
               });
-              existingUtil.lastNotifiedAt = now;
             }
           }
         }

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -305,9 +305,11 @@ export class Monitor {
     const pendingNotifications: WalletNotification[] = [];
     const reminderDigestEntries: ReminderDigestEntry[] = [];
     let shouldSendReminderDigest = false;
+    const metricsCache = new Map<string, ReturnType<typeof computeLoanMetrics>>();
 
     for (const loan of loans) {
       const metrics = computeLoanMetrics(loan);
+      metricsCache.set(loan.id, metrics);
       const adjustedHF = computeRescueAdjustedHF(loan, walletBorrowedAssetBalances);
       const notificationMetrics = { ...metrics, adjustedHF };
       const zone = classifyZone(metrics.healthFactor, this.hydrateZones(config.zones));
@@ -452,7 +454,7 @@ export class Monitor {
     const activeUtilKeys = new Set<string>();
     if (config.utilization.enabled) {
       for (const loan of loans) {
-        const metrics = computeLoanMetrics(loan);
+        const metrics = metricsCache.get(loan.id)!;
         for (const borrowedAsset of loan.borrowed) {
           const assetAddr = borrowedAsset.address.toLowerCase();
           let currentUtilization: number | undefined;
@@ -471,6 +473,8 @@ export class Monitor {
                   ? telemetry.optimalUsageRatio
                   : config.utilization.defaultThreshold;
             } else {
+              const utilKey = `${address}-${loan.id}-${assetAddr}`;
+              activeUtilKeys.add(utilKey);
               continue;
             }
           }
@@ -590,10 +594,14 @@ export class Monitor {
     if (loan.marketName.startsWith('morpho_')) {
       return loan.utilizationRate;
     }
-    const firstBorrowed = loan.borrowed[0];
-    if (!firstBorrowed) return undefined;
-    const telKey = `${loan.marketName}:${firstBorrowed.address.toLowerCase()}`;
-    return telemetryMap.get(telKey)?.utilizationRate;
+    const utilizationRates = loan.borrowed
+      .map((borrowed) => {
+        const telKey = `${loan.marketName}:${borrowed.address.toLowerCase()}`;
+        return telemetryMap.get(telKey)?.utilizationRate;
+      })
+      .filter((rate): rate is number => rate !== undefined);
+    if (utilizationRates.length === 0) return undefined;
+    return Math.max(...utilizationRates);
   }
 
   private hydrateZones(configuredZones: AlertConfig['zones'] | undefined): Zone[] {

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -4,6 +4,7 @@ export type RateSample = {
   timestamp: number; // epoch ms
   borrowRate: number; // weighted decimal, e.g. 0.0325 = 3.25%
   supplyRate: number;
+  utilizationRate: number | null;
 };
 
 export class RateHistoryDb {
@@ -33,20 +34,29 @@ export class RateHistoryDb {
         ON rate_samples (wallet, loan_id, timestamp);
     `);
 
+    // Migration: add utilization_rate column if it doesn't exist yet.
+    try {
+      this.db.exec('ALTER TABLE rate_samples ADD COLUMN utilization_rate REAL');
+    } catch {
+      // Column already exists — ignore.
+    }
+
+    const cols = 'timestamp, borrow_rate, supply_rate, utilization_rate';
+
     this.insertStmt = this.db.prepare(
-      'INSERT OR IGNORE INTO rate_samples (wallet, loan_id, market, timestamp, borrow_rate, supply_rate) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO rate_samples (wallet, loan_id, market, timestamp, borrow_rate, supply_rate, utilization_rate) VALUES (?, ?, ?, ?, ?, ?, ?)',
     );
     this.queryStmt = this.db.prepare(
-      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? ORDER BY timestamp ASC',
+      `SELECT ${cols} FROM rate_samples WHERE wallet = ? AND loan_id = ? ORDER BY timestamp ASC`,
     );
     this.queryFromStmt = this.db.prepare(
-      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? ORDER BY timestamp ASC',
+      `SELECT ${cols} FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? ORDER BY timestamp ASC`,
     );
     this.queryToStmt = this.db.prepare(
-      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp <= ? ORDER BY timestamp ASC',
+      `SELECT ${cols} FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp <= ? ORDER BY timestamp ASC`,
     );
     this.queryRangeStmt = this.db.prepare(
-      'SELECT timestamp, borrow_rate, supply_rate FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC',
+      `SELECT ${cols} FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC`,
     );
     this.pruneStmt = this.db.prepare('DELETE FROM rate_samples WHERE timestamp < ?');
   }
@@ -58,12 +68,26 @@ export class RateHistoryDb {
     timestampMs: number,
     borrowRate: number,
     supplyRate: number,
+    utilizationRate?: number,
   ): void {
-    this.insertStmt.run(wallet.toLowerCase(), loanId, market, timestampMs, borrowRate, supplyRate);
+    this.insertStmt.run(
+      wallet.toLowerCase(),
+      loanId,
+      market,
+      timestampMs,
+      borrowRate,
+      supplyRate,
+      utilizationRate ?? null,
+    );
   }
 
   querySamples(wallet: string, loanId: string, fromMs?: number, toMs?: number): RateSample[] {
-    type Row = { timestamp: number; borrow_rate: number; supply_rate: number };
+    type Row = {
+      timestamp: number;
+      borrow_rate: number;
+      supply_rate: number;
+      utilization_rate: number | null;
+    };
     const w = wallet.toLowerCase();
     let rows: Row[];
     if (fromMs != null && toMs != null) {
@@ -79,6 +103,7 @@ export class RateHistoryDb {
       timestamp: r.timestamp,
       borrowRate: r.borrow_rate,
       supplyRate: r.supply_rate,
+      utilizationRate: r.utilization_rate,
     }));
   }
 

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -35,9 +35,9 @@ export class RateHistoryDb {
     `);
 
     // Migration: add utilization_rate column if it doesn't exist yet.
-    const tableInfo = this.db
-      .prepare("PRAGMA table_info(rate_samples)")
-      .all() as Array<{ name: string }>;
+    const tableInfo = this.db.prepare('PRAGMA table_info(rate_samples)').all() as Array<{
+      name: string;
+    }>;
     const hasUtilizationRate = tableInfo.some((column) => column.name === 'utilization_rate');
     if (!hasUtilizationRate) {
       this.db.exec('ALTER TABLE rate_samples ADD COLUMN utilization_rate REAL');

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -35,10 +35,12 @@ export class RateHistoryDb {
     `);
 
     // Migration: add utilization_rate column if it doesn't exist yet.
-    try {
+    const tableInfo = this.db
+      .prepare("PRAGMA table_info(rate_samples)")
+      .all() as Array<{ name: string }>;
+    const hasUtilizationRate = tableInfo.some((column) => column.name === 'utilization_rate');
+    if (!hasUtilizationRate) {
       this.db.exec('ALTER TABLE rate_samples ADD COLUMN utilization_rate REAL');
-    } catch {
-      // Column already exists — ignore.
     }
 
     const cols = 'timestamp, borrow_rate, supply_rate, utilization_rate';

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -2,9 +2,11 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import {
   DEFAULT_POLLING_CONFIG,
+  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   DEFAULT_ZONES,
   type PollingConfig,
+  type UtilizationConfig,
   type WatchdogConfig as CoreWatchdogConfig,
   type ZoneName,
 } from '@aave-monitor/core';
@@ -32,6 +34,7 @@ export type AlertConfig = {
   polling: PollingConfig;
   zones: ZoneConfig[];
   watchdog: WatchdogConfig;
+  utilization: UtilizationConfig;
 };
 
 const DEFAULT_CONFIG: AlertConfig = {
@@ -50,6 +53,7 @@ const DEFAULT_CONFIG: AlertConfig = {
     { name: 'critical', minHF: 0, maxHF: 1.15 },
   ],
   watchdog: { ...DEFAULT_WATCHDOG_CONFIG },
+  utilization: { ...DEFAULT_UTILIZATION_CONFIG },
 };
 
 function parseEnvFloat(name: string): number | undefined {
@@ -156,6 +160,7 @@ export class ConfigStorage {
       if (config.zones) config.zones = normalizeZones(config.zones);
       // Merge with defaults to support older/partial persisted configs.
       config.watchdog = mergeWatchdogConfig(config.watchdog);
+      config.utilization = { ...DEFAULT_UTILIZATION_CONFIG, ...(config.utilization ?? {}) };
       applyWatchdogEnvOverrides(config.watchdog);
       return config;
     } catch {
@@ -178,7 +183,10 @@ export class ConfigStorage {
   }
 
   update(
-    partial: Partial<Omit<AlertConfig, 'watchdog'>> & { watchdog?: Partial<WatchdogConfig> },
+    partial: Partial<Omit<AlertConfig, 'watchdog' | 'utilization'>> & {
+      watchdog?: Partial<WatchdogConfig>;
+      utilization?: Partial<UtilizationConfig>;
+    },
   ): AlertConfig {
     if (partial.wallets !== undefined) this.config.wallets = partial.wallets;
     if (partial.telegram !== undefined) this.config.telegram = partial.telegram;
@@ -189,6 +197,12 @@ export class ConfigStorage {
         ...this.config.watchdog,
         ...partial.watchdog,
       });
+    }
+    if (partial.utilization !== undefined) {
+      this.config.utilization = {
+        ...this.config.utilization,
+        ...partial.utilization,
+      };
     }
     this.save();
     return this.config;

--- a/packages/server/test/config-schema.test.ts
+++ b/packages/server/test/config-schema.test.ts
@@ -26,3 +26,50 @@ test('parseConfigBody maps legacy maxTopUpWbtc to maxRepayAmount', () => {
   assert.ok('data' in parsed);
   assert.equal(parsed.data.watchdog?.maxRepayAmount, 0.75);
 });
+
+test('parseConfigBody accepts valid utilization config', () => {
+  const parsed = parseConfigBody({
+    utilization: {
+      enabled: true,
+      defaultThreshold: 0.92,
+      cooldownMs: 600_000,
+    },
+  });
+
+  assert.ok('data' in parsed);
+  assert.equal(parsed.data.utilization?.enabled, true);
+  assert.equal(parsed.data.utilization?.defaultThreshold, 0.92);
+  assert.equal(parsed.data.utilization?.cooldownMs, 600_000);
+});
+
+test('parseConfigBody rejects utilization threshold above 1', () => {
+  const parsed = parseConfigBody({
+    utilization: {
+      defaultThreshold: 1.5,
+    },
+  });
+
+  assert.ok('error' in parsed);
+});
+
+test('parseConfigBody rejects utilization threshold below 0', () => {
+  const parsed = parseConfigBody({
+    utilization: {
+      defaultThreshold: -0.1,
+    },
+  });
+
+  assert.ok('error' in parsed);
+});
+
+test('parseConfigBody accepts partial utilization config', () => {
+  const parsed = parseConfigBody({
+    utilization: {
+      enabled: false,
+    },
+  });
+
+  assert.ok('data' in parsed);
+  assert.equal(parsed.data.utilization?.enabled, false);
+  assert.equal(parsed.data.utilization?.defaultThreshold, undefined);
+});

--- a/packages/server/test/monitor.test.ts
+++ b/packages/server/test/monitor.test.ts
@@ -39,6 +39,11 @@ function createConfig(): AlertConfig {
       morphoRescueContract: '',
       maxGasGwei: 50,
     },
+    utilization: {
+      enabled: false,
+      defaultThreshold: 0.9,
+      cooldownMs: 30 * 60 * 1000,
+    },
   };
 }
 

--- a/packages/server/test/monitor.test.ts
+++ b/packages/server/test/monitor.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { Monitor } from '../src/monitor.js';
+import { Monitor, type UtilizationAlertState } from '../src/monitor.js';
 import { logger } from '../src/logger.js';
 import type { AlertConfig } from '../src/storage.js';
 import type { TelegramClient } from '../src/telegram.js';
@@ -558,6 +558,280 @@ test('monitor logs normalize mixed-case symbols and reuse per-loan usdPrice valu
     );
   } finally {
     logger.info = originalInfo;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// --- Utilization alert tests ---
+
+function createMorphoPayloadWithUtilization(utilization: number) {
+  return {
+    data: {
+      userByAddress: {
+        address: WALLET.toLowerCase(),
+        marketPositions: [
+          {
+            market: {
+              uniqueKey: 'morpho-util-1',
+              loanAsset: {
+                symbol: 'USDC',
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                decimals: 6,
+                priceUsd: 1,
+              },
+              collateralAsset: {
+                symbol: 'WETH',
+                address: '0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2',
+                decimals: 18,
+                priceUsd: 2000,
+              },
+              oracleAddress: '0x0000000000000000000000000000000000000001',
+              irmAddress: '0x0000000000000000000000000000000000000002',
+              lltv: '800000000000000000',
+              state: {
+                utilization,
+                borrowApy: 0,
+                supplyApy: 0,
+              },
+            },
+            borrowAssets: String(500 * 1e6),
+            borrowAssetsUsd: 500,
+            supplyAssets: '0',
+            supplyAssetsUsd: 2000,
+            collateral: String(1e18),
+          },
+        ],
+      },
+    },
+  };
+}
+
+function createUtilizationConfig(overrides: Partial<AlertConfig['utilization']> = {}): AlertConfig {
+  return {
+    ...createConfig(),
+    utilization: {
+      enabled: true,
+      defaultThreshold: 0.9,
+      cooldownMs: 30 * 60 * 1000,
+      ...overrides,
+    },
+  };
+}
+
+function mockFetchForMorphoUtilization(utilization: number) {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    const href = String(url);
+    if (href.includes('coingecko.com/api/v3/simple/price')) {
+      return new Response(JSON.stringify({ ethereum: { usd: 2000 }, 'usd-coin': { usd: 1 } }), {
+        status: 200,
+      });
+    }
+    if (href === RPC_URL) {
+      const requests = JSON.parse(String(init?.body)) as Array<{ id: number }>;
+      return new Response(
+        JSON.stringify(requests.map((request) => ({ id: request.id, result: '0x0' }))),
+        { status: 200 },
+      );
+    }
+    if (href.includes('api.morpho.org/graphql')) {
+      return new Response(JSON.stringify(createMorphoPayloadWithUtilization(utilization)), {
+        status: 200,
+      });
+    }
+    if (
+      href.includes('aave/protocol-v3') ||
+      href.includes('Cd2gEDVeqnjBn1hSeqFMitw8Q1iiyV9FYUZkLNRcL87g') ||
+      href.includes('5vxMbXRhG1oQr55MWC5j6qg78waWujx1wjeuEWDA6j3')
+    ) {
+      return new Response(JSON.stringify({ data: { userReserves: [] } }), { status: 200 });
+    }
+    throw new Error(`Unhandled fetch URL: ${href}`);
+  }) as typeof fetch;
+}
+
+function getUtilizationStates(monitor: Monitor): Map<string, UtilizationAlertState> {
+  return (monitor as unknown as { utilizationStates: Map<string, UtilizationAlertState> })
+    .utilizationStates;
+}
+
+test('utilization alert: first observation above threshold with chat on sends alert', async () => {
+  const sentMessages: Array<{ chatId: string; text: string }> = [];
+  const telegram = {
+    sendMessage: async (chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return true;
+    },
+  } as unknown as TelegramClient;
+
+  const config = createUtilizationConfig();
+  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  (monitor.watchdog as { evaluate: (loan: unknown, wallet: string) => Promise<void> }).evaluate =
+    async () => {};
+
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    assert.equal(sentMessages.length, 1);
+    assert.match(sentMessages[0]!.text, /HIGH UTILIZATION/);
+    assert.match(sentMessages[0]!.text, /95\.0%/);
+
+    const states = getUtilizationStates(monitor);
+    assert.equal(states.size, 1);
+    const state = Array.from(states.values())[0]!;
+    assert.equal(state.alerted, true);
+    assert.ok(state.lastNotifiedAt > 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('utilization alert: first observation above threshold with chat off does not mark as alerted', async () => {
+  const telegram = {
+    sendMessage: async () => true,
+  } as unknown as TelegramClient;
+
+  const config = createUtilizationConfig();
+  config.telegram.enabled = false;
+  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  (monitor.watchdog as { evaluate: (loan: unknown, wallet: string) => Promise<void> }).evaluate =
+    async () => {};
+
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    const states = getUtilizationStates(monitor);
+    assert.equal(states.size, 1);
+    const state = Array.from(states.values())[0]!;
+    assert.equal(state.alerted, false);
+    assert.equal(state.lastNotifiedAt, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('utilization alert: below→above transition sends high alert, above→below sends normalized', async () => {
+  const sentMessages: Array<{ chatId: string; text: string }> = [];
+  const telegram = {
+    sendMessage: async (chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return true;
+    },
+  } as unknown as TelegramClient;
+
+  const config = createUtilizationConfig({ cooldownMs: 0 });
+  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  (monitor.watchdog as { evaluate: (loan: unknown, wallet: string) => Promise<void> }).evaluate =
+    async () => {};
+
+  const originalFetch = globalThis.fetch;
+  try {
+    // First poll: below threshold (80%)
+    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+    assert.equal(sentMessages.length, 0);
+
+    // Second poll: above threshold (95%) → should alert
+    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+    assert.equal(sentMessages.length, 1);
+    assert.match(sentMessages[0]!.text, /HIGH UTILIZATION/);
+
+    // Third poll: back below (85%) → should send normalized
+    globalThis.fetch = mockFetchForMorphoUtilization(0.85);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+    assert.equal(sentMessages.length, 2);
+    assert.match(sentMessages[1]!.text, /UTILIZATION NORMALIZED/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('utilization alert: below→above with cooldown active defers alert to next eligible poll', async () => {
+  const sentMessages: Array<{ chatId: string; text: string }> = [];
+  const telegram = {
+    sendMessage: async (chatId: string, text: string) => {
+      sentMessages.push({ chatId, text });
+      return true;
+    },
+  } as unknown as TelegramClient;
+
+  // Use a very long cooldown so the second poll is still within cooldown
+  const config = createUtilizationConfig({ cooldownMs: 999_999_999 });
+  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  (monitor.watchdog as { evaluate: (loan: unknown, wallet: string) => Promise<void> }).evaluate =
+    async () => {};
+
+  const originalFetch = globalThis.fetch;
+  try {
+    // First poll at 80%: below threshold, initializes state with lastNotifiedAt=0
+    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    // Set lastNotifiedAt to now to simulate a recent notification
+    const states = getUtilizationStates(monitor);
+    const state = Array.from(states.values())[0]!;
+    state.lastNotifiedAt = Date.now();
+
+    // Second poll at 95%: above threshold but cooldown is active
+    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    // No alert sent due to cooldown — and alerted is still false
+    assert.equal(sentMessages.length, 0);
+    assert.equal(state.alerted, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('utilization alert: wallet disable cleans up utilization states', async () => {
+  const telegram = {
+    sendMessage: async () => true,
+  } as unknown as TelegramClient;
+
+  const config = createUtilizationConfig();
+  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  (monitor.watchdog as { evaluate: (loan: unknown, wallet: string) => Promise<void> }).evaluate =
+    async () => {};
+
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    const states = getUtilizationStates(monitor);
+    assert.equal(states.size, 1);
+
+    // Disable the wallet
+    config.wallets[0]!.enabled = false;
+    await (monitor as unknown as { poll: (options?: { notify: boolean }) => Promise<void> }).poll({
+      notify: true,
+    });
+
+    assert.equal(states.size, 0);
+  } finally {
     globalThis.fetch = originalFetch;
   }
 });

--- a/packages/server/test/rate-history-db.test.ts
+++ b/packages/server/test/rate-history-db.test.ts
@@ -131,3 +131,23 @@ test('duplicate samples with same wallet/loan/timestamp are silently ignored', (
   assert.equal(samples[0].borrowRate, 0.03);
   db.close();
 });
+
+test('appendSample with utilization stores and returns it', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01, 0.85);
+
+  const samples = db.querySamples('0xabc', 'loan-1');
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].utilizationRate, 0.85);
+  db.close();
+});
+
+test('appendSample without utilization stores null', () => {
+  const db = createDb();
+  db.appendSample('0xabc', 'loan-1', 'market', 1000, 0.03, 0.01);
+
+  const samples = db.querySamples('0xabc', 'loan-1');
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].utilizationRate, null);
+  db.close();
+});

--- a/packages/server/test/runtime.test.ts
+++ b/packages/server/test/runtime.test.ts
@@ -47,6 +47,11 @@ function createConfig(walletEnabled: boolean): AlertConfig {
       morphoRescueContract: '',
       maxGasGwei: 50,
     },
+    utilization: {
+      enabled: false,
+      defaultThreshold: 0.9,
+      cooldownMs: 30 * 60 * 1000,
+    },
   };
 }
 

--- a/packages/server/test/storage.test.ts
+++ b/packages/server/test/storage.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { ConfigStorage, type AlertConfig } from '../src/storage.js';
 
-function createBaseConfig(): Omit<AlertConfig, 'watchdog'> {
+function createBaseConfig(): Omit<AlertConfig, 'watchdog' | 'utilization'> {
   return {
     wallets: [],
     telegram: {
@@ -147,6 +147,49 @@ test('load() maps legacy maxTopUpWbtc field to maxRepayAmount', () => {
     const watchdog = storage.get().watchdog;
 
     assert.equal(watchdog.maxRepayAmount, 0.75);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('load() merges missing utilization fields from defaults', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'aash-storage-test-'));
+  const configPath = join(dir, 'config.json');
+  const saved = {
+    ...createBaseConfig(),
+    watchdog: { enabled: false },
+  };
+
+  try {
+    writeFileSync(configPath, JSON.stringify(saved, null, 2), 'utf-8');
+
+    const storage = new ConfigStorage(configPath);
+    const utilization = storage.get().utilization;
+
+    assert.equal(utilization.enabled, true);
+    assert.equal(utilization.defaultThreshold, 0.9);
+    assert.equal(utilization.cooldownMs, 30 * 60 * 1000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('update() merges partial utilization config with existing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'aash-storage-test-'));
+  const configPath = join(dir, 'config.json');
+
+  try {
+    const storage = new ConfigStorage(configPath);
+    storage.update({
+      utilization: { enabled: false, defaultThreshold: 0.85, cooldownMs: 600_000 },
+    });
+
+    storage.update({ utilization: { defaultThreshold: 0.95 } });
+
+    const utilization = storage.get().utilization;
+    assert.equal(utilization.enabled, false);
+    assert.equal(utilization.defaultThreshold, 0.95);
+    assert.equal(utilization.cooldownMs, 600_000);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/src/components/ServerSettings.tsx
+++ b/src/components/ServerSettings.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { ChevronDown, ChevronRight, Plus, Send, Settings, Trash2, X } from 'lucide-react';
 import {
   DEFAULT_POLLING_CONFIG,
+  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   DEFAULT_ZONES,
   type PollingConfig,
+  type UtilizationConfig,
   type WatchdogConfig,
   type Zone,
 } from '@aave-monitor/core';
@@ -34,6 +36,7 @@ type AlertConfig = {
   polling: PollingConfig;
   zones: ZoneConfig[];
   watchdog: WatchdogConfig;
+  utilization: UtilizationConfig;
 };
 
 const DEFAULT_ZONE_CONFIG: ZoneConfig[] = DEFAULT_ZONES.map(({ name, minHF, maxHF }) => ({
@@ -139,6 +142,10 @@ function normalizeConfig(config: Partial<AlertConfig> | null | undefined): Alert
       ...DEFAULT_WATCHDOG_CONFIG,
       ...(config?.watchdog ?? {}),
     },
+    utilization: {
+      ...DEFAULT_UTILIZATION_CONFIG,
+      ...(config?.utilization ?? {}),
+    },
   };
 }
 
@@ -169,6 +176,7 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
   const [showZones, setShowZones] = useState(false);
   const [showPolling, setShowPolling] = useState(false);
   const [showWatchdog, setShowWatchdog] = useState(false);
+  const [showUtilization, setShowUtilization] = useState(false);
   const [showNotificationSettings, setShowNotificationSettings] = useState(false);
   const [newWalletAddress, setNewWalletAddress] = useState('');
   const [newWalletLabel, setNewWalletLabel] = useState('');
@@ -721,6 +729,104 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
                           void saveConfig(updated);
                         }}
                         className="w-[120px]"
+                      />
+                    </label>
+                  </div>
+                ) : null}
+              </section>
+
+              <Separator />
+
+              <section>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 text-left text-sm font-semibold"
+                  onClick={() => setShowUtilization(!showUtilization)}
+                >
+                  {showUtilization ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                  Utilization Alerts
+                </button>
+                {showUtilization ? (
+                  <div className="mt-3 grid gap-3">
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={config.utilization.enabled}
+                        onChange={() => {
+                          const updated = {
+                            ...config,
+                            utilization: {
+                              ...config.utilization,
+                              enabled: !config.utilization.enabled,
+                            },
+                          };
+                          void saveConfig(updated);
+                        }}
+                        className="accent-primary"
+                      />
+                      Enable utilization alerts
+                    </label>
+
+                    <label className="grid gap-1.5 text-sm">
+                      <span className="text-muted-foreground">Default threshold (%)</span>
+                      <Input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="1"
+                        value={Math.round(config.utilization.defaultThreshold * 100)}
+                        onChange={(e) => {
+                          const updated = {
+                            ...config,
+                            utilization: {
+                              ...config.utilization,
+                              defaultThreshold: Number(e.target.value) / 100,
+                            },
+                          };
+                          setConfig(updated);
+                        }}
+                        onBlur={(e) => {
+                          const updated = {
+                            ...config,
+                            utilization: {
+                              ...config.utilization,
+                              defaultThreshold: Number(e.target.value) / 100,
+                            },
+                          };
+                          void saveConfig(updated);
+                        }}
+                        className="w-[100px]"
+                      />
+                    </label>
+
+                    <label className="grid gap-1.5 text-sm">
+                      <span className="text-muted-foreground">Alert cooldown (minutes)</span>
+                      <Input
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={Math.round(config.utilization.cooldownMs / 60_000)}
+                        onChange={(e) => {
+                          const updated = {
+                            ...config,
+                            utilization: {
+                              ...config.utilization,
+                              cooldownMs: Number(e.target.value) * 60_000,
+                            },
+                          };
+                          setConfig(updated);
+                        }}
+                        onBlur={(e) => {
+                          const updated = {
+                            ...config,
+                            utilization: {
+                              ...config.utilization,
+                              cooldownMs: Number(e.target.value) * 60_000,
+                            },
+                          };
+                          void saveConfig(updated);
+                        }}
+                        className="w-[100px]"
                       />
                     </label>
                   </div>


### PR DESCRIPTION
## Summary
- Alert via Telegram when a loan's market utilization exceeds the target (optimal usage ratio / kink point), where slope2 kicks in and borrow rates spike dramatically
- Send a "normalized" alert when utilization drops back below the threshold
- Configurable via dashboard settings and `/api/config` API: enabled toggle, default threshold (90%), cooldown

## Changes
- **Core types**: `UtilizationConfig` type + `DEFAULT_UTILIZATION_CONFIG` in `aave-core`
- **Server config**: `utilization` field on `AlertConfig` with Zod validation, backward-compatible merge on load
- **Monitor**: Fetches Aave reserve telemetry per unique borrowed asset during poll, tracks per-loan utilization state, sends `utilization-high` / `utilization-normalized` notifications
- **SQLite**: `utilization_rate` column added to `rate_samples` via idempotent `ALTER TABLE ADD COLUMN` migration
- **Dashboard**: Collapsible "Utilization Alerts" section in ServerSettings with enabled toggle, threshold %, and cooldown
- **13 files changed**, 531 insertions

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` clean
- [x] `yarn format:check` clean
- [x] `yarn test` — all 93 tests pass (new tests for rate-history-db, config-schema, storage)
- [ ] Manual: start dev server, configure utilization alerts, verify Telegram alert fires when utilization > target
- [ ] Manual: verify normalized alert fires when utilization drops back

🤖 Generated with [Claude Code](https://claude.com/claude-code)