### PR TITLE
feat: daily interest-accrual history for Morpho positions

### DIFF
--- a/packages/aave-core/src/morpho.ts
+++ b/packages/aave-core/src/morpho.ts
@@ -85,6 +85,7 @@ export type RawMorphoVaultV2Position = {
   assets: string;
   assetsUsd: number | null;
   shares: string;
+  pnlUsd?: number | null;
 };
 
 export type RawMorphoVaultPosition = {
@@ -93,6 +94,7 @@ export type RawMorphoVaultPosition = {
     assets: string;
     assetsUsd: number | null;
     shares: string;
+    pnlUsd?: number | null;
   };
 };
 
@@ -183,6 +185,7 @@ const MORPHO_POSITIONS_QUERY = `
         assets
         assetsUsd
         shares
+        pnlUsd
       }
       vaultPositions {
         vault {
@@ -206,6 +209,7 @@ const MORPHO_POSITIONS_QUERY = `
           assets
           assetsUsd
           shares
+          pnlUsd
         }
       }
     }
@@ -409,6 +413,7 @@ function buildMorphoVaultPosition(
   rawAssets: string,
   rawAssetsUsd: number | null,
   rawShares: string,
+  pnlUsd?: number | null,
 ): MorphoVaultPosition[] {
   const amount = parseAmount(rawAssets, vault.asset.decimals);
   const shareAmount = parseAmount(rawShares, vault.asset.decimals);
@@ -446,19 +451,26 @@ function buildMorphoVaultPosition(
       totalAssetsUsd: usdValue,
       apy,
       netApy,
+      accruedEarningsUsd: pnlUsd ?? undefined,
     },
   ];
 }
 
 function buildMorphoVaultV2Positions(positions: RawMorphoVaultV2Position[]): MorphoVaultPosition[] {
   return positions.flatMap((pos) =>
-    buildMorphoVaultPosition(pos.vault, pos.assets, pos.assetsUsd, pos.shares),
+    buildMorphoVaultPosition(pos.vault, pos.assets, pos.assetsUsd, pos.shares, pos.pnlUsd),
   );
 }
 
 function buildMorphoVaultPositions(positions: RawMorphoVaultPosition[]): MorphoVaultPosition[] {
   return positions.flatMap((pos) =>
-    buildMorphoVaultPosition(pos.vault, pos.state.assets, pos.state.assetsUsd, pos.state.shares),
+    buildMorphoVaultPosition(
+      pos.vault,
+      pos.state.assets,
+      pos.state.assetsUsd,
+      pos.state.shares,
+      pos.state.pnlUsd,
+    ),
   );
 }
 

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -71,6 +71,8 @@ export type MorphoVaultPosition = {
   totalAssetsUsd: number;
   apy: number;
   netApy: number;
+  /** Cumulative earned supply interest (USD) for this vault position when available from Morpho. */
+  accruedEarningsUsd?: number;
 };
 
 export type LoanPosition = {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,6 +41,14 @@ const rateHistoryQuerySchema = z.object({
   to: z.coerce.number().int().optional(),
 });
 
+const interestHistoryQuerySchema = z.object({
+  wallet: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  positionId: z.string().min(1),
+  kind: z.enum(['loan', 'vault']),
+  from: z.coerce.number().int().optional(),
+  to: z.coerce.number().int().optional(),
+});
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_ENV_PATH = join(__dirname, '..', '..', '..', '.env');
 
@@ -253,6 +261,23 @@ app.get('/api/rates/history', (req, res) => {
   const { wallet, loanId, from, to } = parsed.data;
   const samples = rateHistoryDb.querySamples(wallet, loanId, from, to);
   res.json({ samples });
+});
+
+app.get('/api/interest/history', (req, res) => {
+  const parsed = interestHistoryQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid query parameters' });
+    return;
+  }
+  const { wallet, positionId, kind, from, to } = parsed.data;
+  const rows = rateHistoryDb.queryInterestSnapshots(wallet, positionId, kind, from, to);
+  const snapshots = rows.map((row, index) => ({
+    timestamp: row.timestamp,
+    cumulativeUsd: row.cumulativeUsd,
+    deltaUsd: index === 0 ? 0 : row.cumulativeUsd - (rows[index - 1]?.cumulativeUsd ?? 0),
+    label: row.label,
+  }));
+  res.json({ snapshots });
 });
 
 app.get('/api/health', (_req, res) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,7 +16,7 @@ import { logger } from './logger.js';
 import { fetchReserveTelemetry } from './reserveTelemetry.js';
 import { parseConfigBody } from './configSchema.js';
 import { formatStatusMessage } from './statusMessage.js';
-import { RateHistoryDb } from './rateHistoryDb.js';
+import { RateHistoryDb, computeInterestDeltas } from './rateHistoryDb.js';
 import { serializeConfig } from './configResponse.js';
 
 const tokenBalanceRequestSchema = z.object({
@@ -271,13 +271,7 @@ app.get('/api/interest/history', (req, res) => {
   }
   const { wallet, positionId, kind, from, to } = parsed.data;
   const rows = rateHistoryDb.queryInterestSnapshots(wallet, positionId, kind, from, to);
-  const snapshots = rows.map((row, index) => ({
-    timestamp: row.timestamp,
-    cumulativeUsd: row.cumulativeUsd,
-    deltaUsd: index === 0 ? 0 : row.cumulativeUsd - (rows[index - 1]?.cumulativeUsd ?? 0),
-    label: row.label,
-  }));
-  res.json({ snapshots });
+  res.json({ snapshots: computeInterestDeltas(rows) });
 });
 
 app.get('/api/health', (_req, res) => {

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -9,7 +9,7 @@ import {
   isWorsening,
   isImproving,
   fetchFromAaveSubgraph,
-  fetchFromMorphoApi,
+  fetchMorphoPositions,
   fetchTokenBalances,
   fetchUsdPrices,
   buildLoanPositions,
@@ -235,10 +235,12 @@ export class Monitor {
       'Prices resolved',
     );
 
-    const morphoLoans = await fetchFromMorphoApi(address).catch(() => {
+    const morphoPositions = await fetchMorphoPositions(address).catch(() => {
       logger.warn({ wallet: this.shortAddr(address) }, 'Morpho positions unavailable');
-      return [];
+      return { marketLoans: [], vaultPositions: [] };
     });
+    const morphoLoans = morphoPositions.marketLoans;
+    const morphoVaults = morphoPositions.vaultPositions;
     const loans = [...buildLoanPositions(reserves, prices), ...morphoLoans];
 
     // Fetch reserve telemetry for Aave loans when utilization alerts are enabled.
@@ -576,6 +578,55 @@ export class Monitor {
     // Watchdog evaluation pass — runs after alerts so notifications always go out first
     for (const loan of loans) {
       await this.watchdog.evaluate(loan, address);
+    }
+
+    // Daily cumulative-interest snapshots for Morpho positions.
+    // Gated at 23h to allow a bit of drift between polls.
+    if (this.rateHistoryDb) {
+      const MIN_SNAPSHOT_INTERVAL_MS = 23 * 60 * 60 * 1000;
+      for (const loan of morphoLoans) {
+        if (loan.accruedBorrowInterestUsd == null) continue;
+        try {
+          const last = this.rateHistoryDb.getLastInterestSnapshotTs(address, loan.id, 'loan');
+          if (last == null || now - last >= MIN_SNAPSHOT_INTERVAL_MS) {
+            this.rateHistoryDb.appendInterestSnapshot(
+              address,
+              loan.id,
+              'loan',
+              loan.marketName,
+              now,
+              loan.accruedBorrowInterestUsd,
+            );
+          }
+        } catch (err) {
+          logger.warn({ err, loan: loan.id }, 'Failed to record loan interest snapshot');
+        }
+      }
+      for (const vault of morphoVaults) {
+        if (vault.accruedEarningsUsd == null) continue;
+        try {
+          const last = this.rateHistoryDb.getLastInterestSnapshotTs(
+            address,
+            vault.vaultAddress,
+            'vault',
+          );
+          if (last == null || now - last >= MIN_SNAPSHOT_INTERVAL_MS) {
+            this.rateHistoryDb.appendInterestSnapshot(
+              address,
+              vault.vaultAddress,
+              'vault',
+              vault.vaultName,
+              now,
+              vault.accruedEarningsUsd,
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            { err, vault: vault.vaultAddress },
+            'Failed to record vault interest snapshot',
+          );
+        }
+      }
     }
 
     const walletPrefix = `${address}-`;

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -23,7 +23,7 @@ import { Watchdog, type WatchdogLogEntry } from './watchdog.js';
 import { logger } from './logger.js';
 import { computeRescueAdjustedHF } from './rescueMetrics.js';
 import { fetchReserveTelemetry } from './reserveTelemetry.js';
-import type { RateHistoryDb } from './rateHistoryDb.js';
+import { type RateHistoryDb, shouldTakeInterestSnapshot } from './rateHistoryDb.js';
 
 export type LoanAlertState = {
   loanId: string;
@@ -588,7 +588,7 @@ export class Monitor {
         if (loan.accruedBorrowInterestUsd == null) continue;
         try {
           const last = this.rateHistoryDb.getLastInterestSnapshotTs(address, loan.id, 'loan');
-          if (last == null || now - last >= MIN_SNAPSHOT_INTERVAL_MS) {
+          if (shouldTakeInterestSnapshot(last, now, MIN_SNAPSHOT_INTERVAL_MS)) {
             this.rateHistoryDb.appendInterestSnapshot(
               address,
               loan.id,
@@ -610,7 +610,7 @@ export class Monitor {
             vault.vaultAddress,
             'vault',
           );
-          if (last == null || now - last >= MIN_SNAPSHOT_INTERVAL_MS) {
+          if (shouldTakeInterestSnapshot(last, now, MIN_SNAPSHOT_INTERVAL_MS)) {
             this.rateHistoryDb.appendInterestSnapshot(
               address,
               vault.vaultAddress,

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -7,6 +7,14 @@ export type RateSample = {
   utilizationRate: number | null;
 };
 
+export type InterestKind = 'loan' | 'vault';
+
+export type InterestSnapshot = {
+  timestamp: number; // epoch ms
+  cumulativeUsd: number;
+  label: string | null;
+};
+
 export class RateHistoryDb {
   private db: Database.Database;
   private insertStmt: Database.Statement;
@@ -15,6 +23,13 @@ export class RateHistoryDb {
   private queryToStmt: Database.Statement;
   private queryRangeStmt: Database.Statement;
   private pruneStmt: Database.Statement;
+  private insertInterestStmt: Database.Statement;
+  private lastInterestTsStmt: Database.Statement;
+  private queryInterestStmt: Database.Statement;
+  private queryInterestFromStmt: Database.Statement;
+  private queryInterestToStmt: Database.Statement;
+  private queryInterestRangeStmt: Database.Statement;
+  private pruneInterestStmt: Database.Statement;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -61,6 +76,98 @@ export class RateHistoryDb {
       `SELECT ${cols} FROM rate_samples WHERE wallet = ? AND loan_id = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC`,
     );
     this.pruneStmt = this.db.prepare('DELETE FROM rate_samples WHERE timestamp < ?');
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS interest_snapshots (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        wallet         TEXT    NOT NULL,
+        position_id    TEXT    NOT NULL,
+        kind           TEXT    NOT NULL,
+        label          TEXT,
+        timestamp      INTEGER NOT NULL,
+        cumulative_usd REAL    NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_interest_unique
+        ON interest_snapshots (wallet, position_id, kind, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_interest_lookup
+        ON interest_snapshots (wallet, position_id, kind, timestamp DESC);
+    `);
+
+    const interestCols = 'timestamp, cumulative_usd, label';
+    this.insertInterestStmt = this.db.prepare(
+      'INSERT OR IGNORE INTO interest_snapshots (wallet, position_id, kind, label, timestamp, cumulative_usd) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    this.lastInterestTsStmt = this.db.prepare(
+      'SELECT timestamp FROM interest_snapshots WHERE wallet = ? AND position_id = ? AND kind = ? ORDER BY timestamp DESC LIMIT 1',
+    );
+    this.queryInterestStmt = this.db.prepare(
+      `SELECT ${interestCols} FROM interest_snapshots WHERE wallet = ? AND position_id = ? AND kind = ? ORDER BY timestamp ASC`,
+    );
+    this.queryInterestFromStmt = this.db.prepare(
+      `SELECT ${interestCols} FROM interest_snapshots WHERE wallet = ? AND position_id = ? AND kind = ? AND timestamp >= ? ORDER BY timestamp ASC`,
+    );
+    this.queryInterestToStmt = this.db.prepare(
+      `SELECT ${interestCols} FROM interest_snapshots WHERE wallet = ? AND position_id = ? AND kind = ? AND timestamp <= ? ORDER BY timestamp ASC`,
+    );
+    this.queryInterestRangeStmt = this.db.prepare(
+      `SELECT ${interestCols} FROM interest_snapshots WHERE wallet = ? AND position_id = ? AND kind = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC`,
+    );
+    this.pruneInterestStmt = this.db.prepare('DELETE FROM interest_snapshots WHERE timestamp < ?');
+  }
+
+  appendInterestSnapshot(
+    wallet: string,
+    positionId: string,
+    kind: InterestKind,
+    label: string | null,
+    timestampMs: number,
+    cumulativeUsd: number,
+  ): void {
+    this.insertInterestStmt.run(
+      wallet.toLowerCase(),
+      positionId,
+      kind,
+      label,
+      timestampMs,
+      cumulativeUsd,
+    );
+  }
+
+  getLastInterestSnapshotTs(
+    wallet: string,
+    positionId: string,
+    kind: InterestKind,
+  ): number | undefined {
+    const row = this.lastInterestTsStmt.get(wallet.toLowerCase(), positionId, kind) as
+      | { timestamp: number }
+      | undefined;
+    return row?.timestamp;
+  }
+
+  queryInterestSnapshots(
+    wallet: string,
+    positionId: string,
+    kind: InterestKind,
+    fromMs?: number,
+    toMs?: number,
+  ): InterestSnapshot[] {
+    type Row = { timestamp: number; cumulative_usd: number; label: string | null };
+    const w = wallet.toLowerCase();
+    let rows: Row[];
+    if (fromMs != null && toMs != null) {
+      rows = this.queryInterestRangeStmt.all(w, positionId, kind, fromMs, toMs) as Row[];
+    } else if (fromMs != null) {
+      rows = this.queryInterestFromStmt.all(w, positionId, kind, fromMs) as Row[];
+    } else if (toMs != null) {
+      rows = this.queryInterestToStmt.all(w, positionId, kind, toMs) as Row[];
+    } else {
+      rows = this.queryInterestStmt.all(w, positionId, kind) as Row[];
+    }
+    return rows.map((r) => ({
+      timestamp: r.timestamp,
+      cumulativeUsd: r.cumulative_usd,
+      label: r.label,
+    }));
   }
 
   appendSample(
@@ -112,7 +219,8 @@ export class RateHistoryDb {
   prune(maxAgeMs: number): number {
     const cutoff = Date.now() - maxAgeMs;
     const result = this.pruneStmt.run(cutoff);
-    return result.changes;
+    const interestResult = this.pruneInterestStmt.run(cutoff);
+    return result.changes + interestResult.changes;
   }
 
   close(): void {

--- a/packages/server/src/rateHistoryDb.ts
+++ b/packages/server/src/rateHistoryDb.ts
@@ -15,6 +15,40 @@ export type InterestSnapshot = {
   label: string | null;
 };
 
+export type InterestDeltaRow = {
+  timestamp: number;
+  cumulativeUsd: number;
+  deltaUsd: number;
+  label: string | null;
+};
+
+/**
+ * Convert an ascending list of cumulative interest snapshots into rows carrying
+ * both the cumulative value and the delta from the previous row. The first row
+ * has `deltaUsd = 0` since there is no prior baseline in the series.
+ */
+export function computeInterestDeltas(rows: InterestSnapshot[]): InterestDeltaRow[] {
+  return rows.map((row, index) => ({
+    timestamp: row.timestamp,
+    cumulativeUsd: row.cumulativeUsd,
+    deltaUsd: index === 0 ? 0 : row.cumulativeUsd - (rows[index - 1]?.cumulativeUsd ?? 0),
+    label: row.label,
+  }));
+}
+
+/**
+ * Daily-snapshot gate: returns true when enough time has elapsed since the last
+ * snapshot to record a new one. Used by the monitor to throttle writes to ~once
+ * per day per position.
+ */
+export function shouldTakeInterestSnapshot(
+  lastTimestampMs: number | undefined,
+  nowMs: number,
+  minIntervalMs: number,
+): boolean {
+  return lastTimestampMs == null || nowMs - lastTimestampMs >= minIntervalMs;
+}
+
 export class RateHistoryDb {
   private db: Database.Database;
   private insertStmt: Database.Statement;

--- a/packages/server/test/interest-history.test.ts
+++ b/packages/server/test/interest-history.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RateHistoryDb } from '../src/rateHistoryDb.js';
+
+function createDb(): RateHistoryDb {
+  return new RateHistoryDb(':memory:');
+}
+
+test('appendInterestSnapshot round-trips through queryInterestSnapshots', () => {
+  const db = createDb();
+  db.appendInterestSnapshot('0xABC', 'loan-1', 'loan', 'morpho_WETH_USDC', 1000, 12.5);
+
+  const rows = db.queryInterestSnapshots('0xabc', 'loan-1', 'loan');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].timestamp, 1000);
+  assert.equal(rows[0].cumulativeUsd, 12.5);
+  assert.equal(rows[0].label, 'morpho_WETH_USDC');
+  db.close();
+});
+
+test('snapshots are scoped by (wallet, positionId, kind)', () => {
+  const db = createDb();
+  db.appendInterestSnapshot('0xabc', 'same-id', 'loan', null, 1000, 1);
+  db.appendInterestSnapshot('0xabc', 'same-id', 'vault', null, 1000, 2);
+
+  const loans = db.queryInterestSnapshots('0xabc', 'same-id', 'loan');
+  const vaults = db.queryInterestSnapshots('0xabc', 'same-id', 'vault');
+  assert.equal(loans.length, 1);
+  assert.equal(vaults.length, 1);
+  assert.equal(loans[0].cumulativeUsd, 1);
+  assert.equal(vaults[0].cumulativeUsd, 2);
+  db.close();
+});
+
+test('duplicate (wallet, positionId, kind, timestamp) is ignored', () => {
+  const db = createDb();
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 1000, 1);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 1000, 2);
+  const rows = db.queryInterestSnapshots('0xabc', 'loan-1', 'loan');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].cumulativeUsd, 1);
+  db.close();
+});
+
+test('getLastInterestSnapshotTs returns the most recent timestamp', () => {
+  const db = createDb();
+  assert.equal(db.getLastInterestSnapshotTs('0xabc', 'loan-1', 'loan'), undefined);
+
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 1000, 1);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 3000, 3);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 2000, 2);
+
+  assert.equal(db.getLastInterestSnapshotTs('0xabc', 'loan-1', 'loan'), 3000);
+  db.close();
+});
+
+test('queryInterestSnapshots filters by from/to range and sorts ascending', () => {
+  const db = createDb();
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 3000, 3);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 1000, 1);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, 2000, 2);
+
+  const all = db.queryInterestSnapshots('0xabc', 'loan-1', 'loan');
+  assert.deepEqual(
+    all.map((r) => r.timestamp),
+    [1000, 2000, 3000],
+  );
+
+  const ranged = db.queryInterestSnapshots('0xabc', 'loan-1', 'loan', 1500, 2500);
+  assert.equal(ranged.length, 1);
+  assert.equal(ranged[0].timestamp, 2000);
+  db.close();
+});
+
+test('prune also removes old interest snapshots', () => {
+  const db = createDb();
+  const now = Date.now();
+  const day = 24 * 60 * 60 * 1000;
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, now - 200 * day, 1);
+  db.appendInterestSnapshot('0xabc', 'loan-1', 'loan', null, now - 5 * day, 2);
+
+  const deleted = db.prune(180 * day);
+  assert.equal(deleted, 1);
+
+  const rows = db.queryInterestSnapshots('0xabc', 'loan-1', 'loan');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].cumulativeUsd, 2);
+  db.close();
+});

--- a/packages/server/test/interest-history.test.ts
+++ b/packages/server/test/interest-history.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { RateHistoryDb } from '../src/rateHistoryDb.js';
+import {
+  RateHistoryDb,
+  computeInterestDeltas,
+  shouldTakeInterestSnapshot,
+} from '../src/rateHistoryDb.js';
 
 function createDb(): RateHistoryDb {
   return new RateHistoryDb(':memory:');
@@ -70,6 +74,44 @@ test('queryInterestSnapshots filters by from/to range and sorts ascending', () =
   assert.equal(ranged.length, 1);
   assert.equal(ranged[0].timestamp, 2000);
   db.close();
+});
+
+test('computeInterestDeltas returns empty for empty input', () => {
+  assert.deepEqual(computeInterestDeltas([]), []);
+});
+
+test('computeInterestDeltas sets first row delta to 0', () => {
+  const rows = computeInterestDeltas([{ timestamp: 1000, cumulativeUsd: 10, label: 'm' }]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].deltaUsd, 0);
+  assert.equal(rows[0].cumulativeUsd, 10);
+  assert.equal(rows[0].label, 'm');
+});
+
+test('computeInterestDeltas computes signed per-row deltas', () => {
+  const rows = computeInterestDeltas([
+    { timestamp: 1000, cumulativeUsd: 10, label: null },
+    { timestamp: 2000, cumulativeUsd: 15, label: null },
+    { timestamp: 3000, cumulativeUsd: 12, label: null },
+    { timestamp: 4000, cumulativeUsd: 20, label: null },
+  ]);
+  assert.deepEqual(
+    rows.map((r) => r.deltaUsd),
+    [0, 5, -3, 8],
+  );
+});
+
+test('shouldTakeInterestSnapshot with no prior snapshot returns true', () => {
+  assert.equal(shouldTakeInterestSnapshot(undefined, 1000, 100), true);
+});
+
+test('shouldTakeInterestSnapshot returns false before min interval', () => {
+  assert.equal(shouldTakeInterestSnapshot(1000, 1050, 100), false);
+});
+
+test('shouldTakeInterestSnapshot returns true at or after min interval', () => {
+  assert.equal(shouldTakeInterestSnapshot(1000, 1100, 100), true);
+  assert.equal(shouldTakeInterestSnapshot(1000, 1200, 100), true);
 });
 
 test('prune also removes old interest snapshots', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,11 +12,13 @@ import {
 } from '@aave-monitor/core';
 import {
   fetchBorrowRateHistory,
+  fetchInterestHistory,
   fetchReserveTelemetry,
   fetchWalletAssetBalances,
+  type InterestSnapshot,
 } from './api/aaveMonitor';
 import { readBorrowRateHistory, buildBorrowRateHistoryKey } from './lib/borrowRateHistory';
-import { type BorrowRateSample } from './components/ReserveCharts';
+import { InterestAccrualHistoryCard, type BorrowRateSample } from './components/ReserveCharts';
 import { ServerSettings } from './components/ServerSettings';
 import { ToastProvider, ToastViewport } from './components/ui/toast';
 import { type ToastMessage } from './components/ui/toast-context';
@@ -65,6 +67,10 @@ export default function App() {
   );
   const [reserveTelemetryError, setReserveTelemetryError] = useState('');
   const [borrowRateHistory, setBorrowRateHistory] = useState<BorrowRateSample[]>([]);
+  const [loanInterestHistory, setLoanInterestHistory] = useState<InterestSnapshot[]>([]);
+  const [vaultInterestHistories, setVaultInterestHistories] = useState<
+    Record<string, InterestSnapshot[]>
+  >({});
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   const [now, setNow] = useState(() => Date.now());
   const hasAutoFetchedInitialWallet = useRef(false);
@@ -182,6 +188,7 @@ export default function App() {
       setSelectedReserveTelemetry(null); // eslint-disable-line react-hooks/set-state-in-effect -- resetting state on dependency change
       setReserveTelemetryError('');
       setBorrowRateHistory([]);
+      setLoanInterestHistory([]);
       return;
     }
 
@@ -210,8 +217,14 @@ export default function App() {
     });
 
     if (selectedLoan.marketName.startsWith('morpho_')) {
+      void fetchInterestHistory(resolvedWallet, selectedLoan.id, 'loan').then((snapshots) => {
+        if (cancelled) return;
+        setLoanInterestHistory(snapshots);
+      });
       return;
     }
+
+    setLoanInterestHistory([]);
 
     void fetchReserveTelemetry(selectedLoan.marketName, primaryBorrow.address, primaryBorrow.symbol)
       .then((telemetry) => {
@@ -232,6 +245,27 @@ export default function App() {
       cancelled = true;
     };
   }, [result?.lastUpdated, result?.wallet, selectedLoan?.marketName, selectedLoan, wallet]);
+
+  useEffect(() => {
+    const resolvedWallet = result?.wallet;
+    if (!resolvedWallet || !result?.vaults?.length) {
+      setVaultInterestHistories({}); // eslint-disable-line react-hooks/set-state-in-effect -- resetting on dependency change
+      return;
+    }
+    let cancelled = false;
+    void Promise.all(
+      result.vaults.map(async (vault) => {
+        const snapshots = await fetchInterestHistory(resolvedWallet, vault.vaultAddress, 'vault');
+        return [vault.vaultAddress, snapshots] as const;
+      }),
+    ).then((entries) => {
+      if (cancelled) return;
+      setVaultInterestHistories(Object.fromEntries(entries));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [result?.wallet, result?.vaults, result?.lastUpdated]);
 
   const handleFetch = async (event: FormEvent) => {
     event.preventDefault();
@@ -304,9 +338,24 @@ export default function App() {
                     onSelectLoan={setSelectedLoanId}
                   />
                   <VaultPositionsTable vaults={vaultRows} />
+                  {vaultRows.length > 0 ? (
+                    <section className="mt-4 grid gap-4">
+                      {vaultRows.map((vault) => (
+                        <InterestAccrualHistoryCard
+                          key={vault.vaultAddress}
+                          kind="vault"
+                          title={`${vault.vaultName} — Daily Earnings`}
+                          description={`Realized earnings for ${vault.vaultSymbol} derived from Morpho cumulative PnL.`}
+                          snapshots={vaultInterestHistories[vault.vaultAddress] ?? []}
+                          currentTimeMs={now}
+                        />
+                      ))}
+                    </section>
+                  ) : null}
                   <SelectedLoanLabel loan={selectedLoan} />
                   <PositionDetailsSection
                     borrowRateHistory={borrowRateHistory}
+                    loanInterestHistory={loanInterestHistory}
                     computed={computed}
                     now={now}
                     reserveTelemetry={selectedReserveTelemetry}

--- a/src/api/aaveMonitor.ts
+++ b/src/api/aaveMonitor.ts
@@ -26,6 +26,31 @@ export async function fetchBorrowRateHistory(
   }));
 }
 
+export type InterestSnapshot = {
+  timestamp: number;
+  cumulativeUsd: number;
+  deltaUsd: number;
+  label: string | null;
+};
+
+export async function fetchInterestHistory(
+  wallet: string,
+  positionId: string,
+  kind: 'loan' | 'vault',
+  fromMs?: number,
+  toMs?: number,
+): Promise<InterestSnapshot[]> {
+  const params = new URLSearchParams({ wallet, positionId, kind });
+  if (fromMs != null) params.set('from', String(fromMs));
+  if (toMs != null) params.set('to', String(toMs));
+
+  const res = await fetch(`/api/interest/history?${params.toString()}`);
+  if (!res.ok) return [];
+
+  const data = (await res.json()) as { snapshots: InterestSnapshot[] };
+  return data.snapshots;
+}
+
 export async function fetchWalletAssetBalances(
   wallet: string,
   assets: AssetPosition[],

--- a/src/components/ReserveCharts.tsx
+++ b/src/components/ReserveCharts.tsx
@@ -7,6 +7,8 @@ import {
 import {
   LineChart,
   Line,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -17,6 +19,7 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
+import type { InterestSnapshot } from '../api/aaveMonitor';
 
 export type BorrowRateSample = {
   timestamp: string;
@@ -526,6 +529,179 @@ export function BorrowRateHistoryCard({
           <div className="rounded-lg border border-border bg-accent px-4 py-5 text-sm text-muted-foreground">
             Borrow APR history needs at least two reserve snapshots. Keep the dashboard running and
             refreshing to build the chart over time.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+type InterestHistoryWindow = '7d' | '30d' | '90d' | '180d';
+
+const INTEREST_WINDOWS: Array<{ value: InterestHistoryWindow; label: string; durationMs: number }> =
+  [
+    { value: '7d', label: '7d', durationMs: 7 * 24 * 60 * 60 * 1000 },
+    { value: '30d', label: '30d', durationMs: 30 * 24 * 60 * 60 * 1000 },
+    { value: '90d', label: '90d', durationMs: 90 * 24 * 60 * 60 * 1000 },
+    { value: '180d', label: '6m', durationMs: 180 * 24 * 60 * 60 * 1000 },
+  ];
+
+function fmtUsd(value: number): string {
+  const abs = Math.abs(value);
+  const digits = abs >= 100 ? 0 : abs >= 1 ? 2 : 4;
+  return `${value < 0 ? '-' : ''}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })}`;
+}
+
+export function InterestAccrualHistoryCard({
+  snapshots,
+  kind,
+  title,
+  description,
+  currentTimeMs,
+}: {
+  snapshots: InterestSnapshot[];
+  kind: 'loan' | 'vault';
+  title?: string;
+  description?: string;
+  currentTimeMs: number;
+}) {
+  const [windowValue, setWindowValue] = useState<InterestHistoryWindow>('30d');
+
+  const filteredSnapshots = useMemo(() => {
+    const selected = INTEREST_WINDOWS.find((entry) => entry.value === windowValue);
+    if (!selected) return snapshots;
+    const cutoff = currentTimeMs - selected.durationMs;
+    return snapshots.filter((s) => s.timestamp >= cutoff);
+  }, [currentTimeMs, snapshots, windowValue]);
+
+  const { data, totalDelta, avgDelta, maxDelta, maxCumulative } = useMemo(() => {
+    if (filteredSnapshots.length === 0) {
+      return { data: [], totalDelta: 0, avgDelta: 0, maxDelta: 0, maxCumulative: 0 };
+    }
+    // Recompute deltas within the filtered window (first row is baseline, delta=0).
+    const points = filteredSnapshots.map((s, i) => ({
+      timestamp: s.timestamp,
+      deltaUsd: i === 0 ? 0 : s.cumulativeUsd - (filteredSnapshots[i - 1]?.cumulativeUsd ?? 0),
+      cumulativeUsd: s.cumulativeUsd,
+    }));
+    const deltasAfterFirst = points.slice(1).map((p) => p.deltaUsd);
+    const total = deltasAfterFirst.reduce((sum, v) => sum + v, 0);
+    const avg = deltasAfterFirst.length > 0 ? total / deltasAfterFirst.length : 0;
+    const max = deltasAfterFirst.reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    const maxCum = points.reduce((m, p) => Math.max(m, Math.abs(p.cumulativeUsd)), 0);
+    return { data: points, totalDelta: total, avgDelta: avg, maxDelta: max, maxCumulative: maxCum };
+  }, [filteredSnapshots]);
+
+  const xTickFormatter = useMemo(() => {
+    return (v: number) => new Date(v).toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }, []);
+
+  const barColor = kind === 'loan' ? CHART_COLORS.borrow : '#5cd3a8';
+  const defaultTitle = kind === 'loan' ? 'Daily Borrow Interest' : 'Daily Earnings';
+  const totalLabel = kind === 'loan' ? 'Accrued (window)' : 'Earned (window)';
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div>
+          <CardTitle>{title ?? defaultTitle}</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {description ??
+              (kind === 'loan'
+                ? 'Daily borrow interest accrued, derived from Morpho cumulative PnL.'
+                : 'Daily supply earnings, derived from Morpho cumulative vault PnL.')}
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-end gap-1">
+          {INTEREST_WINDOWS.map((entry) => (
+            <Button
+              key={entry.value}
+              type="button"
+              size="sm"
+              variant={windowValue === entry.value ? 'default' : 'secondary'}
+              onClick={() => setWindowValue(entry.value)}
+            >
+              {entry.label}
+            </Button>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        {data.length >= 2 ? (
+          <>
+            <div className="grid gap-1 sm:grid-cols-3">
+              <Stat label={totalLabel} value={fmtUsd(totalDelta)} />
+              <Stat label="Daily avg" value={fmtUsd(avgDelta)} />
+              <Stat label="Max day" value={fmtUsd(maxDelta)} />
+            </div>
+
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart
+                data={data}
+                style={CHART_STYLE}
+                margin={{ top: 8, right: 16, bottom: 8, left: 8 }}
+              >
+                <CartesianGrid strokeDasharray="5 5" stroke={CHART_COLORS.grid} vertical={false} />
+                <XAxis
+                  dataKey="timestamp"
+                  type="number"
+                  scale="time"
+                  domain={['dataMin', 'dataMax']}
+                  tickFormatter={xTickFormatter}
+                  tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={{ stroke: CHART_COLORS.grid }}
+                  minTickGap={30}
+                />
+                <YAxis
+                  tickFormatter={(v: number) => fmtUsd(v)}
+                  tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={60}
+                />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const p = payload[0];
+                    const ts = p?.payload?.timestamp as number | undefined;
+                    const delta = Number(p?.payload?.deltaUsd ?? 0);
+                    const cumulative = Number(p?.payload?.cumulativeUsd ?? 0);
+                    return (
+                      <div className="rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-lg">
+                        {ts && (
+                          <p className="mb-1 font-medium text-muted-foreground">
+                            {new Date(ts).toLocaleDateString([], {
+                              month: 'short',
+                              day: 'numeric',
+                              year: 'numeric',
+                            })}
+                          </p>
+                        )}
+                        <p style={{ color: barColor }} className="font-semibold">
+                          {kind === 'loan' ? 'Interest' : 'Earnings'}: {fmtUsd(delta)}
+                        </p>
+                        <p className="text-muted-foreground">Cumulative: {fmtUsd(cumulative)}</p>
+                      </div>
+                    );
+                  }}
+                  cursor={{ fill: 'rgba(139, 158, 179, 0.15)' }}
+                />
+                <ReferenceLine y={0} stroke={CHART_COLORS.grid} />
+                <Bar dataKey="deltaUsd" name="Daily" fill={barColor} radius={[3, 3, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+            <p className="text-xs text-muted-foreground">
+              Cumulative at end of window: {fmtUsd(maxCumulative)}
+            </p>
+          </>
+        ) : (
+          <div className="rounded-lg border border-border bg-accent px-4 py-5 text-sm text-muted-foreground">
+            Need at least two daily snapshots to chart interest. Keep the server running — snapshots
+            are recorded every ~24h.
           </div>
         )}
       </CardContent>

--- a/src/components/ReserveCharts.tsx
+++ b/src/components/ReserveCharts.tsx
@@ -7,8 +7,8 @@ import {
 import {
   LineChart,
   Line,
-  BarChart,
   Bar,
+  ComposedChart,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -577,9 +577,9 @@ export function InterestAccrualHistoryCard({
     return snapshots.filter((s) => s.timestamp >= cutoff);
   }, [currentTimeMs, snapshots, windowValue]);
 
-  const { data, totalDelta, avgDelta, maxDelta, maxCumulative } = useMemo(() => {
+  const { data, totalDelta, avgDelta, maxDelta, endCumulative } = useMemo(() => {
     if (filteredSnapshots.length === 0) {
-      return { data: [], totalDelta: 0, avgDelta: 0, maxDelta: 0, maxCumulative: 0 };
+      return { data: [], totalDelta: 0, avgDelta: 0, maxDelta: 0, endCumulative: 0 };
     }
     // Recompute deltas within the filtered window (first row is baseline, delta=0).
     const points = filteredSnapshots.map((s, i) => ({
@@ -591,8 +591,8 @@ export function InterestAccrualHistoryCard({
     const total = deltasAfterFirst.reduce((sum, v) => sum + v, 0);
     const avg = deltasAfterFirst.length > 0 ? total / deltasAfterFirst.length : 0;
     const max = deltasAfterFirst.reduce((m, v) => Math.max(m, Math.abs(v)), 0);
-    const maxCum = points.reduce((m, p) => Math.max(m, Math.abs(p.cumulativeUsd)), 0);
-    return { data: points, totalDelta: total, avgDelta: avg, maxDelta: max, maxCumulative: maxCum };
+    const end = points[points.length - 1]?.cumulativeUsd ?? 0;
+    return { data: points, totalDelta: total, avgDelta: avg, maxDelta: max, endCumulative: end };
   }, [filteredSnapshots]);
 
   const xTickFormatter = useMemo(() => {
@@ -638,8 +638,8 @@ export function InterestAccrualHistoryCard({
               <Stat label="Max day" value={fmtUsd(maxDelta)} />
             </div>
 
-            <ResponsiveContainer width="100%" height={260}>
-              <BarChart
+            <ResponsiveContainer width="100%" height={280}>
+              <ComposedChart
                 data={data}
                 style={CHART_STYLE}
                 margin={{ top: 8, right: 16, bottom: 8, left: 8 }}
@@ -657,6 +657,16 @@ export function InterestAccrualHistoryCard({
                   minTickGap={30}
                 />
                 <YAxis
+                  yAxisId="delta"
+                  tickFormatter={(v: number) => fmtUsd(v)}
+                  tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={60}
+                />
+                <YAxis
+                  yAxisId="cumulative"
+                  orientation="right"
                   tickFormatter={(v: number) => fmtUsd(v)}
                   tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
                   tickLine={false}
@@ -690,12 +700,29 @@ export function InterestAccrualHistoryCard({
                   }}
                   cursor={{ fill: 'rgba(139, 158, 179, 0.15)' }}
                 />
-                <ReferenceLine y={0} stroke={CHART_COLORS.grid} />
-                <Bar dataKey="deltaUsd" name="Daily" fill={barColor} radius={[3, 3, 0, 0]} />
-              </BarChart>
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <ReferenceLine yAxisId="delta" y={0} stroke={CHART_COLORS.grid} />
+                <Bar
+                  yAxisId="delta"
+                  dataKey="deltaUsd"
+                  name="Daily"
+                  fill={barColor}
+                  radius={[3, 3, 0, 0]}
+                />
+                <Line
+                  yAxisId="cumulative"
+                  type="monotone"
+                  dataKey="cumulativeUsd"
+                  name="Cumulative"
+                  stroke={CHART_COLORS.supply}
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+              </ComposedChart>
             </ResponsiveContainer>
             <p className="text-xs text-muted-foreground">
-              Cumulative at end of window: {fmtUsd(maxCumulative)}
+              Cumulative at end of window: {fmtUsd(endCumulative)}
             </p>
           </>
         ) : (

--- a/src/components/dashboard/PositionDetails.tsx
+++ b/src/components/dashboard/PositionDetails.tsx
@@ -2,10 +2,12 @@ import { AlertTriangle, Info, ShieldCheck } from 'lucide-react';
 import { clamp, healthLabel, type Computed, type LoanPosition } from '@aave-monitor/core';
 import {
   BorrowRateHistoryCard,
+  InterestAccrualHistoryCard,
   MorphoIrmCard,
   type BorrowRateSample,
   UtilizationCurveCard,
 } from '../ReserveCharts';
+import type { InterestSnapshot } from '../../api/aaveMonitor';
 import { Badge } from '../ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Separator } from '../ui/separator';
@@ -27,6 +29,7 @@ export function SelectedLoanLabel({ loan }: { loan: LoanPosition | null }) {
 
 export function PositionDetailsSection({
   borrowRateHistory,
+  loanInterestHistory,
   computed,
   now,
   reserveTelemetry,
@@ -34,12 +37,14 @@ export function PositionDetailsSection({
   selectedLoan,
 }: {
   borrowRateHistory: BorrowRateSample[];
+  loanInterestHistory: InterestSnapshot[];
   computed: Computed;
   now: number;
   reserveTelemetry: ReserveTelemetry | null;
   reserveTelemetryError: string;
   selectedLoan: LoanPosition | null;
 }) {
+  const isMorphoLoan = selectedLoan?.marketName.startsWith('morpho_') ?? false;
   return (
     <section className="mt-2 grid gap-4 [grid-template-columns:minmax(320px,0.95fr)_minmax(0,2fr)] max-[980px]:grid-cols-1">
       <PositionSnapshotCard computed={computed} selectedLoan={selectedLoan} />
@@ -75,6 +80,14 @@ export function PositionDetailsSection({
           samples={borrowRateHistory}
           reserve={reserveTelemetry}
         />
+
+        {isMorphoLoan ? (
+          <InterestAccrualHistoryCard
+            kind="loan"
+            snapshots={loanInterestHistory}
+            currentTimeMs={now}
+          />
+        ) : null}
 
         <MetricsGrid computed={computed} selectedLoan={selectedLoan} />
         <MonitoringChecklistCard computed={computed} />


### PR DESCRIPTION
## Summary

Tracks **daily accrued borrow interest** for Morpho market loans and **daily earned interest** for Morpho vault positions. Snapshots are persisted to SQLite, surfaced through a new API endpoint, and rendered as per-position bar charts in the dashboard with selectable windows (7d / 30d / 90d / 6m).

Aave loans are intentionally out of scope for this change — they don't currently expose a cumulative interest field we can snapshot.

## What's new

### Backend

- **Morpho data** (`packages/aave-core/src/morpho.ts`, `types.ts`): GraphQL query now requests `pnlUsd` on `vaultPositions` and `vaultV2Positions`; `MorphoVaultPosition` gains `accruedEarningsUsd`. Loans already expose `accruedBorrowInterestUsd` via `borrowPnlUsd` — no change needed there.
- **Storage** (`packages/server/src/rateHistoryDb.ts`): new `interest_snapshots` table storing `(wallet, position_id, kind='loan'|'vault', label, timestamp, cumulative_usd)` with a unique `(wallet, position_id, kind, timestamp)` index. Added `appendInterestSnapshot`, `getLastInterestSnapshotTs`, and `queryInterestSnapshots` helpers; `prune()` now also covers this table under the existing 180-day retention.
- **Monitor** (`packages/server/src/monitor.ts`): switched from `fetchFromMorphoApi` to `fetchMorphoPositions` so the poll loop has vault data too. After per-wallet alerting + watchdog, a new pass writes a cumulative interest snapshot per Morpho loan and vault if ≥ 23h have passed since the last one. DB failures are logged and don't interrupt core monitoring.
- **API** (`packages/server/src/index.ts`): new `GET /api/interest/history?wallet=&positionId=&kind=loan|vault&from=&to=`. Returns `{ timestamp, cumulativeUsd, deltaUsd, label }[]` with server-computed deltas (first row delta = 0) so the frontend stays dumb. Zod-validated params.

### Frontend

- **API client** (`src/api/aaveMonitor.ts`): `fetchInterestHistory(wallet, positionId, kind, from?, to?)` + exported `InterestSnapshot` type.
- **Chart component** (`src/components/ReserveCharts.tsx`): new `InterestAccrualHistoryCard` — recharts `BarChart` of daily deltas with stats footer (window total, daily avg, max day). Recomputes deltas within the selected window so the first in-window bar is a true baseline. Shows an empty-state message until at least 2 snapshots exist.
- **Wiring**:
  - `src/components/dashboard/PositionDetails.tsx`: renders the card for Morpho loans next to the IR/APR charts (hidden for Aave loans).
  - `src/App.tsx`: fetches loan interest history for the selected Morpho loan, and a map of vault interest histories keyed by vault address. Adds a new section of vault earnings cards beneath `VaultPositionsTable`, one per Morpho vault.

### Testing

- `packages/server/test/interest-history.test.ts` — 6 new tests: round-trip, `(wallet, positionId, kind)` scoping, dedupe on duplicate timestamps, `getLastInterestSnapshotTs`, range filtering with ascending sort, prune behavior.

## Design notes

- **Cumulative vs delta storage**: we store cumulative USD and derive daily deltas at read time. This is robust against gaps/missed polls and makes range queries trivial — deltas within the selected window are computed on the fly from filtered cumulative values.
- **23h gating** (not strict EOD): the first poll after the 23h mark writes the snapshot. Simpler than scheduling actual EOD writes, and good enough for daily granularity. The ~1h slack absorbs poll drift and restarts.
- **Cumulative source**: for loans we use Morpho's `borrowPnlUsd`; for vaults we use `pnlUsd` on the vault position state. Deltas reflect whatever Morpho reports, including negative swings (e.g. rebases) — the UI handles signed deltas correctly.
- **ORM not introduced**: kept raw `better-sqlite3` — still only two small tables with typed helper methods. Noted as a follow-up if schema growth makes it worthwhile.

## Test plan

- [x] `yarn format:check` passes
- [x] `yarn lint` passes
- [x] `yarn typecheck` passes (app + node + core + server)
- [x] `yarn test` passes (106/106)
- [x] `yarn dev:server` + `yarn dev` with a wallet that has a Morpho loan + Morpho vault; verify the new cards render the "need at least two snapshots" fallback initially.
- [ ] After two poll cycles spanning ≥23h (or with a temporarily lowered `MIN_SNAPSHOT_INTERVAL_MS`), confirm the charts populate and window switches (7d/30d/90d/6m) work.
- [ ] Hit `GET /api/interest/history?wallet=…&positionId=…&kind=loan` directly; spot-check `deltaUsd = cumulative[i] - cumulative[i-1]` and `deltaUsd = 0` for the first row.
- [ ] Confirm no regressions on `/api/rates/history` or the IR/APR charts.
- [ ] Confirm pruning: insert an old snapshot (>180d), call `prune()`, verify it's removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)