### PR TITLE
Replace utilization alert with borrow-rate alert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ Backend server notes:
 - Watchdog user-facing docs live in `docs/watchdog-user-manual.md`.
 - Watchdog uses an atomic on-chain rescue path: it computes the required debt-token repay amount off-chain and submits a single `rescue(...)` transaction to the configured rescue contract, which repays the loan's borrowed asset (e.g. USDC/USDT) from the monitored wallet.
 - Watchdog is fully wired: monitor integration, `GET /api/watchdog/status` endpoint, `/watchdog` Telegram command, config via `GET/PUT /api/config`, and dashboard settings controls for watchdog fields.
-- `GET /api/config` and `PUT /api/config` round-trip both `watchdog` and `utilization` settings so dashboard/server alert config stays in sync.
+- `GET /api/config` and `PUT /api/config` round-trip both `watchdog` and `borrowRate` settings so dashboard/server alert config stays in sync.
+- Borrow-rate alerts fire when a loan's weighted borrow rate crosses the hardcoded `BORROW_RATE_ALERT_THRESHOLD` (4.5%). They replace the old market-utilization alert; only the alert was removed — telemetry, the dashboard "Utilization %" column, and the utilization curve chart all stay.
 - `zones[].maxHF` accepts JSON `null` on `PUT /api/config` and is normalized to `Infinity` (important because JSON serialization turns `Infinity` into `null`).
 - Legacy configs that omit one or more zones are hydrated back to the full default six-zone set by name, so runtime, `/api/config`, and the dashboard stay aligned.
 - Monitor runtime is driven by enabled wallets (not Telegram enablement), so watchdog polling can run without Telegram configured.
@@ -108,7 +109,7 @@ Frontend structure:
 - `src/hooks/usePortfolioMonitor.ts` owns wallet loading, auto-refresh timers, portfolio history, and loan/vault selection state
 - `src/hooks/usePositionDetailsData.ts` owns server-backed detail queries for the selected loan or vault (borrow rate history, reserve telemetry, interest history)
 - `src/components/dashboard/*` renders wallet search, summary cards, loan/vault tables, and loan detail panels
-- `src/components/ServerSettings.tsx` owns the alert/watchdog/utilization settings drawer and `/api/config` integration
+- `src/components/ServerSettings.tsx` owns the alert/watchdog/borrow-rate settings drawer and `/api/config` integration
 - `src/api/aaveMonitor.ts` contains frontend API calls for server-backed data such as reserve telemetry, rate history, and portfolio history
 - `packages/aave-core/src/*` owns shared protocol fetchers, position builders, and portfolio math used by both frontend and backend
 

--- a/packages/aave-core/src/constants.ts
+++ b/packages/aave-core/src/constants.ts
@@ -1,4 +1,4 @@
-import type { AaveMarket, PollingConfig, UtilizationConfig, WatchdogConfig } from './types.js';
+import type { AaveMarket, BorrowRateConfig, PollingConfig, WatchdogConfig } from './types.js';
 
 export const AAVE_MARKETS: readonly AaveMarket[] = [
   {
@@ -84,9 +84,11 @@ export const DEFAULT_POLLING_CONFIG: PollingConfig = {
   cooldownMs: 30 * 60 * 1000,
 };
 
-export const DEFAULT_UTILIZATION_CONFIG: UtilizationConfig = {
+/** Borrow-rate threshold (decimal, e.g. 0.045 = 4.5%) above which a high-rate alert fires. */
+export const BORROW_RATE_ALERT_THRESHOLD = 0.045;
+
+export const DEFAULT_BORROW_RATE_CONFIG: BorrowRateConfig = {
   enabled: true,
-  defaultThreshold: 0.9,
   cooldownMs: 30 * 60 * 1000,
 };
 

--- a/packages/aave-core/src/index.ts
+++ b/packages/aave-core/src/index.ts
@@ -15,15 +15,16 @@ export type {
   RawUserReserve,
   RawUserReserveWithMarket,
   ReserveTelemetry,
-  UtilizationConfig,
+  BorrowRateConfig,
   WatchdogConfig,
 } from './types.js';
 
 export {
   AAVE_MARKETS,
   COINGECKO_IDS_BY_SYMBOL,
+  BORROW_RATE_ALERT_THRESHOLD,
+  DEFAULT_BORROW_RATE_CONFIG,
   DEFAULT_POLLING_CONFIG,
-  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   ETHEREUM_ADDRESS_REGEX,
   STABLECOIN_CONTRACTS,

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -200,10 +200,8 @@ export type InterestRateCurvePoint = {
   variableBorrowRate: number;
 };
 
-export type UtilizationConfig = {
+export type BorrowRateConfig = {
   enabled: boolean;
-  /** Default trigger threshold (0–1). Used when on-chain optimalUsageRatio unavailable. */
-  defaultThreshold: number;
-  /** Cooldown between alerts for same asset (ms). */
+  /** Cooldown between alerts for the same loan (ms). */
   cooldownMs: number;
 };

--- a/packages/server/src/configResponse.ts
+++ b/packages/server/src/configResponse.ts
@@ -7,6 +7,6 @@ export function serializeConfig(config: AlertConfig) {
     polling: config.polling,
     zones: config.zones,
     watchdog: config.watchdog,
-    utilization: config.utilization,
+    borrowRate: config.borrowRate,
   };
 }

--- a/packages/server/src/configSchema.ts
+++ b/packages/server/src/configSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { UtilizationConfig } from '@aave-monitor/core';
+import type { BorrowRateConfig } from '@aave-monitor/core';
 import type { AlertConfig, WatchdogConfig } from './storage.js';
 
 const partialWatchdogConfigSchema = z
@@ -57,19 +57,18 @@ export const partialAlertConfigSchema = z
       }),
     ),
     watchdog: partialWatchdogConfigSchema,
-    utilization: z
+    borrowRate: z
       .object({
         enabled: z.boolean(),
-        defaultThreshold: z.number().min(0).max(1),
         cooldownMs: z.number().positive(),
       })
       .partial(),
   })
   .partial();
 
-export type ConfigUpdate = Partial<Omit<AlertConfig, 'watchdog' | 'utilization'>> & {
+export type ConfigUpdate = Partial<Omit<AlertConfig, 'watchdog' | 'borrowRate'>> & {
   watchdog?: Partial<WatchdogConfig>;
-  utilization?: Partial<UtilizationConfig>;
+  borrowRate?: Partial<BorrowRateConfig>;
 };
 
 export function parseConfigBody(body: unknown): { data: ConfigUpdate } | { error: string } {

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -25,7 +25,13 @@ import type { TelegramClient } from './telegram.js';
 import { Watchdog, type WatchdogLogEntry } from './watchdog.js';
 import { logger } from './logger.js';
 import { computeRescueAdjustedHF } from './rescueMetrics.js';
-import { fetchReserveTelemetry } from './reserveTelemetry.js';
+import { fetchReserveTelemetry as defaultFetchReserveTelemetry } from './reserveTelemetry.js';
+
+export type ReserveTelemetryFetcher = (
+  marketName: string,
+  assetAddress: string,
+  rpcUrl: string,
+) => Promise<ReserveTelemetry>;
 import { type RateHistoryDb } from './rateHistoryDb.js';
 
 export type LoanAlertState = {
@@ -101,6 +107,7 @@ export class Monitor {
     private readonly rpcUrl: string,
     privateKey: string | undefined,
     private readonly rateHistoryDb?: RateHistoryDb,
+    private readonly fetchReserveTelemetry: ReserveTelemetryFetcher = defaultFetchReserveTelemetry,
   ) {
     this.watchdog = new Watchdog(
       telegram,
@@ -255,9 +262,8 @@ export class Monitor {
 
     // Fetch reserve telemetry for Aave loans (used for /status utilization display
     // and rate-history utilization samples). Deduplicate by (marketName, assetAddress).
-    // Gated on borrowRate.enabled to keep tests offline by default.
     const telemetryMap = new Map<string, ReserveTelemetry>();
-    if (config.borrowRate.enabled) {
+    {
       const telemetryKeys = new Map<string, { marketName: string; assetAddress: string }>();
       for (const loan of loans) {
         if (loan.marketName.startsWith('morpho_')) continue;
@@ -273,7 +279,7 @@ export class Monitor {
       }
       const results = await Promise.allSettled(
         Array.from(telemetryKeys.entries()).map(async ([key, { marketName, assetAddress }]) => {
-          const telemetry = await fetchReserveTelemetry(marketName, assetAddress, this.rpcUrl);
+          const telemetry = await this.fetchReserveTelemetry(marketName, assetAddress, this.rpcUrl);
           return { key, telemetry };
         }),
       );

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -6,6 +6,7 @@ import {
   type ReserveTelemetry,
   type Zone,
   type ZoneName,
+  BORROW_RATE_ALERT_THRESHOLD,
   classifyZone,
   isWorsening,
   isImproving,
@@ -47,26 +48,22 @@ export type LoanAlertState = {
   stuckSince: number | null;
 };
 
-export type UtilizationAlertState = {
+export type BorrowRateAlertState = {
   wallet: string;
   loanId: string;
   marketName: string;
-  assetAddress: string;
-  assetSymbol: string;
   /** Whether we have already sent an "exceeded" alert */
   alerted: boolean;
-  /** Timestamp of last utilization alert sent */
+  /** Timestamp of last borrow-rate alert sent */
   lastNotifiedAt: number;
-  /** Last observed utilization rate (0–1) */
-  lastUtilization: number;
-  /** The threshold that was used (from on-chain optimalUsageRatio or config default) */
-  threshold: number;
+  /** Last observed borrow rate (0–1) */
+  lastBorrowRate: number;
 };
 
 export type MonitorStatus = {
   running: boolean;
   states: LoanAlertState[];
-  utilizationStates: UtilizationAlertState[];
+  borrowRateStates: BorrowRateAlertState[];
   vaults: MorphoVaultPosition[];
   totalWalletBorrowedAssetUsd: number;
   lastPollAt: number | null;
@@ -75,13 +72,7 @@ export type MonitorStatus = {
 };
 
 type WalletNotification = {
-  kind:
-    | 'transition'
-    | 'recovery'
-    | 'all-clear'
-    | 'reminder'
-    | 'utilization-high'
-    | 'utilization-normalized';
+  kind: 'transition' | 'recovery' | 'all-clear' | 'reminder' | 'rate-high' | 'rate-normalized';
   message: string;
 };
 
@@ -92,7 +83,7 @@ type ReminderDigestEntry = {
 
 export class Monitor {
   private states = new Map<string, LoanAlertState>();
-  private utilizationStates = new Map<string, UtilizationAlertState>();
+  private borrowRateStates = new Map<string, BorrowRateAlertState>();
   private vaultPositions = new Map<string, MorphoVaultPosition>();
   private timerId: ReturnType<typeof setInterval> | null = null;
   private walletBorrowedAssetUsd = new Map<string, number>();
@@ -152,7 +143,7 @@ export class Monitor {
     return {
       running: this.running,
       states: Array.from(this.states.values()),
-      utilizationStates: Array.from(this.utilizationStates.values()),
+      borrowRateStates: Array.from(this.borrowRateStates.values()),
       vaults: Array.from(this.vaultPositions.values()),
       totalWalletBorrowedAssetUsd: Array.from(this.walletBorrowedAssetUsd.values()).reduce(
         (sum, value) => sum + value,
@@ -188,9 +179,9 @@ export class Monitor {
         this.walletBorrowedAssetUsd.delete(existingAddress);
       }
     }
-    for (const [utilKey, utilState] of Array.from(this.utilizationStates.entries())) {
-      if (!enabledAddresses.has(utilState.wallet.toLowerCase())) {
-        this.utilizationStates.delete(utilKey);
+    for (const [rateKey, rateState] of Array.from(this.borrowRateStates.entries())) {
+      if (!enabledAddresses.has(rateState.wallet.toLowerCase())) {
+        this.borrowRateStates.delete(rateKey);
       }
     }
     for (const vaultKey of Array.from(this.vaultPositions.keys())) {
@@ -262,10 +253,11 @@ export class Monitor {
       this.vaultPositions.set(vaultKey, vault);
     }
 
-    // Fetch reserve telemetry for Aave loans when utilization alerts are enabled.
-    // Deduplicate by (marketName, assetAddress) to avoid redundant RPC calls.
+    // Fetch reserve telemetry for Aave loans (used for /status utilization display
+    // and rate-history utilization samples). Deduplicate by (marketName, assetAddress).
+    // Gated on borrowRate.enabled to keep tests offline by default.
     const telemetryMap = new Map<string, ReserveTelemetry>();
-    if (config.utilization.enabled) {
+    if (config.borrowRate.enabled) {
       const telemetryKeys = new Map<string, { marketName: string; assetAddress: string }>();
       for (const loan of loans) {
         if (loan.marketName.startsWith('morpho_')) continue;
@@ -475,103 +467,59 @@ export class Monitor {
       }
     }
 
-    // Utilization alert pass — independent of HF zone transitions
-    const activeUtilKeys = new Set<string>();
-    if (config.utilization.enabled) {
+    // Borrow-rate alert pass — independent of HF zone transitions.
+    // Fires when a loan's weighted borrow rate crosses BORROW_RATE_ALERT_THRESHOLD.
+    const activeRateKeys = new Set<string>();
+    if (config.borrowRate.enabled) {
       for (const loan of loans) {
         const metrics = metricsCache.get(loan.id)!;
-        for (const borrowedAsset of loan.borrowed) {
-          const assetAddr = borrowedAsset.address.toLowerCase();
-          let currentUtilization: number | undefined;
-          let threshold: number;
+        const currentRate = metrics.rBorrow;
+        if (!Number.isFinite(currentRate)) continue;
 
-          if (loan.marketName.startsWith('morpho_')) {
-            currentUtilization = loan.utilizationRate;
-            threshold = config.utilization.defaultThreshold;
-          } else {
-            const telKey = `${loan.marketName}:${assetAddr}`;
-            const telemetry = telemetryMap.get(telKey);
-            if (telemetry) {
-              currentUtilization = telemetry.utilizationRate;
-              threshold =
-                telemetry.optimalUsageRatio > 0
-                  ? telemetry.optimalUsageRatio
-                  : config.utilization.defaultThreshold;
-            } else {
-              const utilKey = `${address}-${loan.id}-${assetAddr}`;
-              activeUtilKeys.add(utilKey);
-              continue;
-            }
-          }
+        const rateKey = `${address}-${loan.id}`;
+        activeRateKeys.add(rateKey);
+        const existingRate = this.borrowRateStates.get(rateKey);
+        const threshold = BORROW_RATE_ALERT_THRESHOLD;
 
-          if (currentUtilization == null) continue;
-
-          const utilKey = `${address}-${loan.id}-${assetAddr}`;
-          activeUtilKeys.add(utilKey);
-          const existingUtil = this.utilizationStates.get(utilKey);
-
-          if (!existingUtil) {
-            const isAbove = currentUtilization >= threshold;
-            const sent = isAbove && chatId;
-            this.utilizationStates.set(utilKey, {
-              wallet: address,
-              loanId: loan.id,
-              marketName: loan.marketName,
-              assetAddress: assetAddr,
-              assetSymbol: borrowedAsset.symbol,
-              alerted: sent ? true : false,
-              lastNotifiedAt: sent ? now : 0,
-              lastUtilization: currentUtilization,
-              threshold,
+        if (!existingRate) {
+          const isAbove = currentRate >= threshold;
+          const sent = isAbove && chatId;
+          this.borrowRateStates.set(rateKey, {
+            wallet: address,
+            loanId: loan.id,
+            marketName: loan.marketName,
+            alerted: sent ? true : false,
+            lastNotifiedAt: sent ? now : 0,
+            lastBorrowRate: currentRate,
+          });
+          if (sent) {
+            pendingNotifications.push({
+              kind: 'rate-high',
+              message: this.formatBorrowRateHigh(loan, currentRate, threshold, metrics),
             });
-            if (sent) {
-              pendingNotifications.push({
-                kind: 'utilization-high',
-                message: this.formatUtilizationHigh(
-                  loan,
-                  borrowedAsset,
-                  currentUtilization,
-                  threshold,
-                  metrics,
-                ),
-              });
-            }
-            continue;
           }
+          continue;
+        }
 
-          existingUtil.lastUtilization = currentUtilization;
-          existingUtil.threshold = threshold;
+        existingRate.lastBorrowRate = currentRate;
 
-          if (currentUtilization >= threshold && !existingUtil.alerted) {
-            if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
-              existingUtil.alerted = true;
-              existingUtil.lastNotifiedAt = now;
-              pendingNotifications.push({
-                kind: 'utilization-high',
-                message: this.formatUtilizationHigh(
-                  loan,
-                  borrowedAsset,
-                  currentUtilization,
-                  threshold,
-                  metrics,
-                ),
-              });
-            }
-          } else if (currentUtilization < threshold && existingUtil.alerted) {
-            if (chatId && now - existingUtil.lastNotifiedAt >= config.utilization.cooldownMs) {
-              existingUtil.alerted = false;
-              existingUtil.lastNotifiedAt = now;
-              pendingNotifications.push({
-                kind: 'utilization-normalized',
-                message: this.formatUtilizationNormalized(
-                  loan,
-                  borrowedAsset,
-                  currentUtilization,
-                  threshold,
-                  metrics,
-                ),
-              });
-            }
+        if (currentRate >= threshold && !existingRate.alerted) {
+          if (chatId && now - existingRate.lastNotifiedAt >= config.borrowRate.cooldownMs) {
+            existingRate.alerted = true;
+            existingRate.lastNotifiedAt = now;
+            pendingNotifications.push({
+              kind: 'rate-high',
+              message: this.formatBorrowRateHigh(loan, currentRate, threshold, metrics),
+            });
+          }
+        } else if (currentRate < threshold && existingRate.alerted) {
+          if (chatId && now - existingRate.lastNotifiedAt >= config.borrowRate.cooldownMs) {
+            existingRate.alerted = false;
+            existingRate.lastNotifiedAt = now;
+            pendingNotifications.push({
+              kind: 'rate-normalized',
+              message: this.formatBorrowRateNormalized(loan, currentRate, threshold, metrics),
+            });
           }
         }
       }
@@ -683,9 +631,9 @@ export class Monitor {
         this.states.delete(stateKey);
       }
     }
-    for (const utilKey of Array.from(this.utilizationStates.keys())) {
-      if (utilKey.startsWith(walletPrefix) && !activeUtilKeys.has(utilKey)) {
-        this.utilizationStates.delete(utilKey);
+    for (const rateKey of Array.from(this.borrowRateStates.keys())) {
+      if (rateKey.startsWith(walletPrefix) && !activeRateKeys.has(rateKey)) {
+        this.borrowRateStates.delete(rateKey);
       }
     }
     for (const vaultKey of Array.from(this.vaultPositions.keys())) {
@@ -830,47 +778,45 @@ export class Monitor {
     ].join('\n');
   }
 
-  private formatUtilizationHigh(
-    loan: { marketName: string },
-    asset: { symbol: string },
-    utilization: number,
+  private formatBorrowRateHigh(
+    loan: { marketName: string; borrowed: { symbol: string }[] },
+    borrowRate: number,
     threshold: number,
-    metrics: { healthFactor: number; rBorrow: number },
+    metrics: { healthFactor: number },
   ): string {
-    const utilPct = (utilization * 100).toFixed(1);
-    const threshPct = (threshold * 100).toFixed(1);
+    const ratePct = (borrowRate * 100).toFixed(2);
+    const threshPct = (threshold * 100).toFixed(2);
     const hf = Number.isFinite(metrics.healthFactor) ? metrics.healthFactor.toFixed(2) : '\u221E';
 
     return [
-      `\u26A0\uFE0F <b>HIGH UTILIZATION</b> \u2014 Rate Spike Risk`,
+      `\u26A0\uFE0F <b>HIGH BORROW RATE</b>`,
       '',
-      `Market: ${loan.marketName} \u00B7 ${asset.symbol}`,
-      `Utilization: <b>${utilPct}%</b> (target: ${threshPct}%)`,
-      `HF: <b>${hf}</b> \u00B7 Borrow rate: <b>${this.formatBorrowRate(metrics.rBorrow)}</b>`,
+      `Market: ${loan.marketName} \u00B7 ${loan.borrowed.map((b) => b.symbol).join('+')}`,
+      `Borrow rate: <b>${ratePct}%</b> (threshold: ${threshPct}%)`,
+      `HF: <b>${hf}</b>`,
       '',
-      `Utilization above target \u2014 borrow rates may spike sharply.`,
+      `Borrow rate is above ${threshPct}% \u2014 consider reducing exposure or repaying debt.`,
     ].join('\n');
   }
 
-  private formatUtilizationNormalized(
-    loan: { marketName: string },
-    asset: { symbol: string },
-    utilization: number,
+  private formatBorrowRateNormalized(
+    loan: { marketName: string; borrowed: { symbol: string }[] },
+    borrowRate: number,
     threshold: number,
-    metrics: { healthFactor: number; rBorrow: number },
+    metrics: { healthFactor: number },
   ): string {
-    const utilPct = (utilization * 100).toFixed(1);
-    const threshPct = (threshold * 100).toFixed(1);
+    const ratePct = (borrowRate * 100).toFixed(2);
+    const threshPct = (threshold * 100).toFixed(2);
     const hf = Number.isFinite(metrics.healthFactor) ? metrics.healthFactor.toFixed(2) : '\u221E';
 
     return [
-      `\u2705 <b>UTILIZATION NORMALIZED</b>`,
+      `\u2705 <b>BORROW RATE NORMALIZED</b>`,
       '',
-      `Market: ${loan.marketName} \u00B7 ${asset.symbol}`,
-      `Utilization: <b>${utilPct}%</b> (target: ${threshPct}%)`,
-      `HF: <b>${hf}</b> \u00B7 Borrow rate: <b>${this.formatBorrowRate(metrics.rBorrow)}</b>`,
+      `Market: ${loan.marketName} \u00B7 ${loan.borrowed.map((b) => b.symbol).join('+')}`,
+      `Borrow rate: <b>${ratePct}%</b> (threshold: ${threshPct}%)`,
+      `HF: <b>${hf}</b>`,
       '',
-      `Utilization back below target \u2014 borrow rates returning to normal.`,
+      `Borrow rate back below ${threshPct}%.`,
     ].join('\n');
   }
 
@@ -904,10 +850,10 @@ export class Monitor {
           ? 'Recovery'
           : kind === 'all-clear'
             ? 'All Clear'
-            : kind === 'utilization-high'
-              ? 'High Utilization'
-              : kind === 'utilization-normalized'
-                ? 'Utilization Normalized'
+            : kind === 'rate-high'
+              ? 'High Borrow Rate'
+              : kind === 'rate-normalized'
+                ? 'Borrow Rate Normalized'
                 : 'Reminder';
     return `${base} ${index + 1}`;
   }

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -1,12 +1,12 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import {
+  DEFAULT_BORROW_RATE_CONFIG,
   DEFAULT_POLLING_CONFIG,
-  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   DEFAULT_ZONES,
+  type BorrowRateConfig,
   type PollingConfig,
-  type UtilizationConfig,
   type WatchdogConfig as CoreWatchdogConfig,
   type ZoneName,
 } from '@aave-monitor/core';
@@ -34,7 +34,7 @@ export type AlertConfig = {
   polling: PollingConfig;
   zones: ZoneConfig[];
   watchdog: WatchdogConfig;
-  utilization: UtilizationConfig;
+  borrowRate: BorrowRateConfig;
 };
 
 const DEFAULT_CONFIG: AlertConfig = {
@@ -53,7 +53,7 @@ const DEFAULT_CONFIG: AlertConfig = {
     { name: 'critical', minHF: 0, maxHF: 1.15 },
   ],
   watchdog: { ...DEFAULT_WATCHDOG_CONFIG },
-  utilization: { ...DEFAULT_UTILIZATION_CONFIG },
+  borrowRate: { ...DEFAULT_BORROW_RATE_CONFIG },
 };
 
 function parseEnvFloat(name: string): number | undefined {
@@ -160,7 +160,7 @@ export class ConfigStorage {
       if (config.zones) config.zones = normalizeZones(config.zones);
       // Merge with defaults to support older/partial persisted configs.
       config.watchdog = mergeWatchdogConfig(config.watchdog);
-      config.utilization = { ...DEFAULT_UTILIZATION_CONFIG, ...(config.utilization ?? {}) };
+      config.borrowRate = { ...DEFAULT_BORROW_RATE_CONFIG, ...(config.borrowRate ?? {}) };
       applyWatchdogEnvOverrides(config.watchdog);
       return config;
     } catch {
@@ -183,9 +183,9 @@ export class ConfigStorage {
   }
 
   update(
-    partial: Partial<Omit<AlertConfig, 'watchdog' | 'utilization'>> & {
+    partial: Partial<Omit<AlertConfig, 'watchdog' | 'borrowRate'>> & {
       watchdog?: Partial<WatchdogConfig>;
-      utilization?: Partial<UtilizationConfig>;
+      borrowRate?: Partial<BorrowRateConfig>;
     },
   ): AlertConfig {
     if (partial.wallets !== undefined) this.config.wallets = partial.wallets;
@@ -198,10 +198,10 @@ export class ConfigStorage {
         ...partial.watchdog,
       });
     }
-    if (partial.utilization !== undefined) {
-      this.config.utilization = {
-        ...this.config.utilization,
-        ...partial.utilization,
+    if (partial.borrowRate !== undefined) {
+      this.config.borrowRate = {
+        ...this.config.borrowRate,
+        ...partial.borrowRate,
       };
     }
     this.save();

--- a/packages/server/test/config-response.test.ts
+++ b/packages/server/test/config-response.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { serializeConfig } from '../src/configResponse.js';
 import type { AlertConfig } from '../src/storage.js';
 
-test('serializeConfig includes utilization settings', () => {
+test('serializeConfig includes borrow rate settings', () => {
   const config: AlertConfig = {
     wallets: [{ address: '0x1111111111111111111111111111111111111111', enabled: true }],
     telegram: {
@@ -37,14 +37,13 @@ test('serializeConfig includes utilization settings', () => {
       morphoRescueContract: '',
       maxGasGwei: 50,
     },
-    utilization: {
+    borrowRate: {
       enabled: true,
-      defaultThreshold: 0.92,
       cooldownMs: 600_000,
     },
   };
 
   const serialized = serializeConfig(config);
 
-  assert.deepEqual(serialized.utilization, config.utilization);
+  assert.deepEqual(serialized.borrowRate, config.borrowRate);
 });

--- a/packages/server/test/config-schema.test.ts
+++ b/packages/server/test/config-schema.test.ts
@@ -27,49 +27,37 @@ test('parseConfigBody maps legacy maxTopUpWbtc to maxRepayAmount', () => {
   assert.equal(parsed.data.watchdog?.maxRepayAmount, 0.75);
 });
 
-test('parseConfigBody accepts valid utilization config', () => {
+test('parseConfigBody accepts valid borrow rate config', () => {
   const parsed = parseConfigBody({
-    utilization: {
+    borrowRate: {
       enabled: true,
-      defaultThreshold: 0.92,
       cooldownMs: 600_000,
     },
   });
 
   assert.ok('data' in parsed);
-  assert.equal(parsed.data.utilization?.enabled, true);
-  assert.equal(parsed.data.utilization?.defaultThreshold, 0.92);
-  assert.equal(parsed.data.utilization?.cooldownMs, 600_000);
+  assert.equal(parsed.data.borrowRate?.enabled, true);
+  assert.equal(parsed.data.borrowRate?.cooldownMs, 600_000);
 });
 
-test('parseConfigBody rejects utilization threshold above 1', () => {
+test('parseConfigBody rejects non-positive borrow rate cooldown', () => {
   const parsed = parseConfigBody({
-    utilization: {
-      defaultThreshold: 1.5,
+    borrowRate: {
+      cooldownMs: 0,
     },
   });
 
   assert.ok('error' in parsed);
 });
 
-test('parseConfigBody rejects utilization threshold below 0', () => {
+test('parseConfigBody accepts partial borrow rate config', () => {
   const parsed = parseConfigBody({
-    utilization: {
-      defaultThreshold: -0.1,
-    },
-  });
-
-  assert.ok('error' in parsed);
-});
-
-test('parseConfigBody accepts partial utilization config', () => {
-  const parsed = parseConfigBody({
-    utilization: {
+    borrowRate: {
       enabled: false,
     },
   });
 
   assert.ok('data' in parsed);
-  assert.equal(parsed.data.utilization?.enabled, false);
-  assert.equal(parsed.data.utilization?.defaultThreshold, undefined);
+  assert.equal(parsed.data.borrowRate?.enabled, false);
+  assert.equal(parsed.data.borrowRate?.cooldownMs, undefined);
 });

--- a/packages/server/test/monitor.test.ts
+++ b/packages/server/test/monitor.test.ts
@@ -31,6 +31,10 @@ function stubWatchdogEvaluate(monitor: Monitor) {
   getMonitorInternals(monitor).watchdog.evaluate = async () => {};
 }
 
+const stubTelemetryFetcher = async () => {
+  throw new Error('telemetry stubbed in tests');
+};
+
 function createTelegramStub(
   sentMessages?: Array<{ chatId: string; text: string }>,
 ): TelegramClient {
@@ -163,7 +167,16 @@ test('groups multiple loan alerts for the same wallet into one telegram message'
   const sentMessages: Array<{ chatId: string; text: string }> = [];
   const telegram = createTelegramStub(sentMessages);
 
-  const monitor = new Monitor(telegram, createConfig, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    createConfig,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   let phase: 'initial' | 'critical' = 'initial';
@@ -242,7 +255,16 @@ test('wallet reminder digest includes all non-safe loans when any loan is due', 
   const sentMessages: Array<{ chatId: string; text: string }> = [];
   const telegram = createTelegramStub(sentMessages);
 
-  const monitor = new Monitor(telegram, createConfig, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    createConfig,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -328,7 +350,16 @@ test('wallet reminder digest includes all non-safe loans when any loan is due', 
 test('monitor state uses wallet debt-token balances to project rescue-adjusted HF', async () => {
   const telegram = createTelegramStub();
 
-  const monitor = new Monitor(telegram, createConfig, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    createConfig,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -404,7 +435,16 @@ test('monitor state uses wallet debt-token balances to project rescue-adjusted H
 test('monitor logs normalize mixed-case symbols and reuse per-loan usdPrice values', async () => {
   const telegram = createTelegramStub();
 
-  const monitor = new Monitor(telegram, createConfig, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    createConfig,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -654,7 +694,16 @@ test('borrow rate alert: first observation above threshold with chat on sends al
   const telegram = createTelegramStub(sentMessages);
 
   const config = createBorrowRateConfig();
-  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    () => config,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -682,7 +731,16 @@ test('borrow rate alert: first observation above threshold with chat off does no
 
   const config = createBorrowRateConfig();
   config.telegram.enabled = false;
-  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    () => config,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -706,7 +764,16 @@ test('borrow rate alert: below→above transition sends high alert, above→belo
   const telegram = createTelegramStub(sentMessages);
 
   const config = createBorrowRateConfig({ cooldownMs: 0 });
-  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    () => config,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -737,7 +804,16 @@ test('borrow rate alert: below→above with cooldown active defers alert to next
   const telegram = createTelegramStub(sentMessages);
 
   const config = createBorrowRateConfig({ cooldownMs: 999_999_999 });
-  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    () => config,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
@@ -765,7 +841,16 @@ test('borrow rate alert: wallet disable cleans up borrow rate states', async () 
   const telegram = createTelegramStub();
 
   const config = createBorrowRateConfig();
-  const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
+  const monitor = new Monitor(
+    telegram,
+    () => config,
+    undefined,
+    undefined,
+    RPC_URL,
+    undefined,
+    undefined,
+    stubTelemetryFetcher,
+  );
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;

--- a/packages/server/test/monitor.test.ts
+++ b/packages/server/test/monitor.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { Monitor, type UtilizationAlertState } from '../src/monitor.js';
+import { Monitor, type BorrowRateAlertState } from '../src/monitor.js';
 import { logger } from '../src/logger.js';
 import type { AlertConfig } from '../src/storage.js';
 import type { TelegramClient } from '../src/telegram.js';
@@ -20,7 +20,7 @@ type MonitorInternals = {
       lastNotifiedAt: number;
     }
   >;
-  utilizationStates: Map<string, UtilizationAlertState>;
+  borrowRateStates: Map<string, BorrowRateAlertState>;
 };
 
 function getMonitorInternals(monitor: Monitor): MonitorInternals {
@@ -77,9 +77,8 @@ function createConfig(): AlertConfig {
       morphoRescueContract: '',
       maxGasGwei: 50,
     },
-    utilization: {
+    borrowRate: {
       enabled: false,
-      defaultThreshold: 0.9,
       cooldownMs: 30 * 60 * 1000,
     },
   };
@@ -560,9 +559,9 @@ test('monitor logs normalize mixed-case symbols and reuse per-loan usdPrice valu
   }
 });
 
-// --- Utilization alert tests ---
+// --- Borrow rate alert tests ---
 
-function createMorphoPayloadWithUtilization(utilization: number) {
+function createMorphoPayloadWithBorrowApy(borrowApy: number) {
   return {
     data: {
       userByAddress: {
@@ -570,7 +569,7 @@ function createMorphoPayloadWithUtilization(utilization: number) {
         marketPositions: [
           {
             market: {
-              uniqueKey: 'morpho-util-1',
+              uniqueKey: 'morpho-rate-1',
               loanAsset: {
                 symbol: 'USDC',
                 address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -587,8 +586,8 @@ function createMorphoPayloadWithUtilization(utilization: number) {
               irmAddress: '0x0000000000000000000000000000000000000002',
               lltv: '800000000000000000',
               state: {
-                utilization,
-                borrowApy: 0,
+                utilization: 0.5,
+                borrowApy,
                 supplyApy: 0,
               },
             },
@@ -604,19 +603,18 @@ function createMorphoPayloadWithUtilization(utilization: number) {
   };
 }
 
-function createUtilizationConfig(overrides: Partial<AlertConfig['utilization']> = {}): AlertConfig {
+function createBorrowRateConfig(overrides: Partial<AlertConfig['borrowRate']> = {}): AlertConfig {
   return {
     ...createConfig(),
-    utilization: {
+    borrowRate: {
       enabled: true,
-      defaultThreshold: 0.9,
       cooldownMs: 30 * 60 * 1000,
       ...overrides,
     },
   };
 }
 
-function mockFetchForMorphoUtilization(utilization: number) {
+function mockFetchForMorphoBorrowApy(borrowApy: number) {
   return (async (url: string | URL | Request, init?: RequestInit) => {
     const href = String(url);
     if (href.includes('coingecko.com/api/v3/simple/price')) {
@@ -632,7 +630,7 @@ function mockFetchForMorphoUtilization(utilization: number) {
       );
     }
     if (href.includes('api.morpho.org/graphql')) {
-      return new Response(JSON.stringify(createMorphoPayloadWithUtilization(utilization)), {
+      return new Response(JSON.stringify(createMorphoPayloadWithBorrowApy(borrowApy)), {
         status: 200,
       });
     }
@@ -647,29 +645,29 @@ function mockFetchForMorphoUtilization(utilization: number) {
   }) as typeof fetch;
 }
 
-function getUtilizationStates(monitor: Monitor): Map<string, UtilizationAlertState> {
-  return getMonitorInternals(monitor).utilizationStates;
+function getBorrowRateStates(monitor: Monitor): Map<string, BorrowRateAlertState> {
+  return getMonitorInternals(monitor).borrowRateStates;
 }
 
-test('utilization alert: first observation above threshold with chat on sends alert', async () => {
+test('borrow rate alert: first observation above threshold with chat on sends alert', async () => {
   const sentMessages: Array<{ chatId: string; text: string }> = [];
   const telegram = createTelegramStub(sentMessages);
 
-  const config = createUtilizationConfig();
+  const config = createBorrowRateConfig();
   const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
   try {
-    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.06);
 
     await pollMonitor(monitor, true);
 
     assert.equal(sentMessages.length, 1);
-    assert.match(sentMessages[0]!.text, /HIGH UTILIZATION/);
-    assert.match(sentMessages[0]!.text, /95\.0%/);
+    assert.match(sentMessages[0]!.text, /HIGH BORROW RATE/);
+    assert.match(sentMessages[0]!.text, /6\.00%/);
 
-    const states = getUtilizationStates(monitor);
+    const states = getBorrowRateStates(monitor);
     assert.equal(states.size, 1);
     const state = Array.from(states.values())[0]!;
     assert.equal(state.alerted, true);
@@ -679,21 +677,21 @@ test('utilization alert: first observation above threshold with chat on sends al
   }
 });
 
-test('utilization alert: first observation above threshold with chat off does not mark as alerted', async () => {
+test('borrow rate alert: first observation above threshold with chat off does not mark as alerted', async () => {
   const telegram = createTelegramStub();
 
-  const config = createUtilizationConfig();
+  const config = createBorrowRateConfig();
   config.telegram.enabled = false;
   const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
   try {
-    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.06);
 
     await pollMonitor(monitor, true);
 
-    const states = getUtilizationStates(monitor);
+    const states = getBorrowRateStates(monitor);
     assert.equal(states.size, 1);
     const state = Array.from(states.values())[0]!;
     assert.equal(state.alerted, false);
@@ -703,62 +701,59 @@ test('utilization alert: first observation above threshold with chat off does no
   }
 });
 
-test('utilization alert: below→above transition sends high alert, above→below sends normalized', async () => {
+test('borrow rate alert: below→above transition sends high alert, above→below sends normalized', async () => {
   const sentMessages: Array<{ chatId: string; text: string }> = [];
   const telegram = createTelegramStub(sentMessages);
 
-  const config = createUtilizationConfig({ cooldownMs: 0 });
+  const config = createBorrowRateConfig({ cooldownMs: 0 });
   const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
   try {
-    // First poll: below threshold (80%)
-    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    // First poll: below threshold (3%)
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.03);
     await pollMonitor(monitor, true);
     assert.equal(sentMessages.length, 0);
 
-    // Second poll: above threshold (95%) → should alert
-    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    // Second poll: above threshold (6%) → should alert
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.06);
     await pollMonitor(monitor, true);
     assert.equal(sentMessages.length, 1);
-    assert.match(sentMessages[0]!.text, /HIGH UTILIZATION/);
+    assert.match(sentMessages[0]!.text, /HIGH BORROW RATE/);
 
-    // Third poll: back below (85%) → should send normalized
-    globalThis.fetch = mockFetchForMorphoUtilization(0.85);
+    // Third poll: back below (4%) → should send normalized
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.04);
     await pollMonitor(monitor, true);
     assert.equal(sentMessages.length, 2);
-    assert.match(sentMessages[1]!.text, /UTILIZATION NORMALIZED/);
+    assert.match(sentMessages[1]!.text, /BORROW RATE NORMALIZED/);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test('utilization alert: below→above with cooldown active defers alert to next eligible poll', async () => {
+test('borrow rate alert: below→above with cooldown active defers alert to next eligible poll', async () => {
   const sentMessages: Array<{ chatId: string; text: string }> = [];
   const telegram = createTelegramStub(sentMessages);
 
-  // Use a very long cooldown so the second poll is still within cooldown
-  const config = createUtilizationConfig({ cooldownMs: 999_999_999 });
+  const config = createBorrowRateConfig({ cooldownMs: 999_999_999 });
   const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
   try {
-    // First poll at 80%: below threshold, initializes state with lastNotifiedAt=0
-    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    // First poll at 3%: below threshold, initializes state with lastNotifiedAt=0
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.03);
     await pollMonitor(monitor, true);
 
-    // Set lastNotifiedAt to now to simulate a recent notification
-    const states = getUtilizationStates(monitor);
+    const states = getBorrowRateStates(monitor);
     const state = Array.from(states.values())[0]!;
     state.lastNotifiedAt = Date.now();
 
-    // Second poll at 95%: above threshold but cooldown is active
-    globalThis.fetch = mockFetchForMorphoUtilization(0.95);
+    // Second poll at 6%: above threshold but cooldown is active
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.06);
     await pollMonitor(monitor, true);
 
-    // No alert sent due to cooldown — and alerted is still false
     assert.equal(sentMessages.length, 0);
     assert.equal(state.alerted, false);
   } finally {
@@ -766,22 +761,21 @@ test('utilization alert: below→above with cooldown active defers alert to next
   }
 });
 
-test('utilization alert: wallet disable cleans up utilization states', async () => {
+test('borrow rate alert: wallet disable cleans up borrow rate states', async () => {
   const telegram = createTelegramStub();
 
-  const config = createUtilizationConfig();
+  const config = createBorrowRateConfig();
   const monitor = new Monitor(telegram, () => config, undefined, undefined, RPC_URL, undefined);
   stubWatchdogEvaluate(monitor);
 
   const originalFetch = globalThis.fetch;
   try {
-    globalThis.fetch = mockFetchForMorphoUtilization(0.8);
+    globalThis.fetch = mockFetchForMorphoBorrowApy(0.03);
     await pollMonitor(monitor, true);
 
-    const states = getUtilizationStates(monitor);
+    const states = getBorrowRateStates(monitor);
     assert.equal(states.size, 1);
 
-    // Disable the wallet
     config.wallets[0]!.enabled = false;
     await pollMonitor(monitor, true);
 

--- a/packages/server/test/runtime.test.ts
+++ b/packages/server/test/runtime.test.ts
@@ -47,9 +47,8 @@ function createConfig(walletEnabled: boolean): AlertConfig {
       morphoRescueContract: '',
       maxGasGwei: 50,
     },
-    utilization: {
+    borrowRate: {
       enabled: false,
-      defaultThreshold: 0.9,
       cooldownMs: 30 * 60 * 1000,
     },
   };

--- a/packages/server/test/storage.test.ts
+++ b/packages/server/test/storage.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { ConfigStorage, type AlertConfig } from '../src/storage.js';
 
-function createBaseConfig(): Omit<AlertConfig, 'watchdog' | 'utilization'> {
+function createBaseConfig(): Omit<AlertConfig, 'watchdog' | 'borrowRate'> {
   return {
     wallets: [],
     telegram: {
@@ -152,7 +152,7 @@ test('load() maps legacy maxTopUpWbtc field to maxRepayAmount', () => {
   }
 });
 
-test('load() merges missing utilization fields from defaults', () => {
+test('load() merges missing borrowRate fields from defaults', () => {
   const dir = mkdtempSync(join(tmpdir(), 'aash-storage-test-'));
   const configPath = join(dir, 'config.json');
   const saved = {
@@ -164,32 +164,30 @@ test('load() merges missing utilization fields from defaults', () => {
     writeFileSync(configPath, JSON.stringify(saved, null, 2), 'utf-8');
 
     const storage = new ConfigStorage(configPath);
-    const utilization = storage.get().utilization;
+    const borrowRate = storage.get().borrowRate;
 
-    assert.equal(utilization.enabled, true);
-    assert.equal(utilization.defaultThreshold, 0.9);
-    assert.equal(utilization.cooldownMs, 30 * 60 * 1000);
+    assert.equal(borrowRate.enabled, true);
+    assert.equal(borrowRate.cooldownMs, 30 * 60 * 1000);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('update() merges partial utilization config with existing', () => {
+test('update() merges partial borrowRate config with existing', () => {
   const dir = mkdtempSync(join(tmpdir(), 'aash-storage-test-'));
   const configPath = join(dir, 'config.json');
 
   try {
     const storage = new ConfigStorage(configPath);
     storage.update({
-      utilization: { enabled: false, defaultThreshold: 0.85, cooldownMs: 600_000 },
+      borrowRate: { enabled: false, cooldownMs: 600_000 },
     });
 
-    storage.update({ utilization: { defaultThreshold: 0.95 } });
+    storage.update({ borrowRate: { cooldownMs: 900_000 } });
 
-    const utilization = storage.get().utilization;
-    assert.equal(utilization.enabled, false);
-    assert.equal(utilization.defaultThreshold, 0.95);
-    assert.equal(utilization.cooldownMs, 600_000);
+    const borrowRate = storage.get().borrowRate;
+    assert.equal(borrowRate.enabled, false);
+    assert.equal(borrowRate.cooldownMs, 900_000);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/src/components/ServerSettings.tsx
+++ b/src/components/ServerSettings.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ChevronDown, ChevronRight, Plus, Send, Settings, Trash2, X } from 'lucide-react';
 import {
+  BORROW_RATE_ALERT_THRESHOLD,
+  DEFAULT_BORROW_RATE_CONFIG,
   DEFAULT_POLLING_CONFIG,
-  DEFAULT_UTILIZATION_CONFIG,
   DEFAULT_WATCHDOG_CONFIG,
   DEFAULT_ZONES,
+  type BorrowRateConfig,
   type PollingConfig,
-  type UtilizationConfig,
   type WatchdogConfig,
   type Zone,
 } from '@aave-monitor/core';
@@ -36,7 +37,7 @@ type AlertConfig = {
   polling: PollingConfig;
   zones: ZoneConfig[];
   watchdog: WatchdogConfig;
-  utilization: UtilizationConfig;
+  borrowRate: BorrowRateConfig;
 };
 
 const DEFAULT_ZONE_CONFIG: ZoneConfig[] = DEFAULT_ZONES.map(({ name, minHF, maxHF }) => ({
@@ -142,9 +143,9 @@ function normalizeConfig(config: Partial<AlertConfig> | null | undefined): Alert
       ...DEFAULT_WATCHDOG_CONFIG,
       ...(config?.watchdog ?? {}),
     },
-    utilization: {
-      ...DEFAULT_UTILIZATION_CONFIG,
-      ...(config?.utilization ?? {}),
+    borrowRate: {
+      ...DEFAULT_BORROW_RATE_CONFIG,
+      ...(config?.borrowRate ?? {}),
     },
   };
 }
@@ -176,7 +177,7 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
   const [showZones, setShowZones] = useState(false);
   const [showPolling, setShowPolling] = useState(false);
   const [showWatchdog, setShowWatchdog] = useState(false);
-  const [showUtilization, setShowUtilization] = useState(false);
+  const [showBorrowRate, setShowBorrowRate] = useState(false);
   const [showNotificationSettings, setShowNotificationSettings] = useState(false);
   const [newWalletAddress, setNewWalletAddress] = useState('');
   const [newWalletLabel, setNewWalletLabel] = useState('');
@@ -288,14 +289,14 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
     );
   };
 
-  const updateUtilization = (
-    patch: Partial<AlertConfig['utilization']>,
+  const updateBorrowRate = (
+    patch: Partial<AlertConfig['borrowRate']>,
     options?: { persist?: boolean },
   ) => {
     applyConfigUpdate(
       (current) => ({
         ...current,
-        utilization: { ...current.utilization, ...patch },
+        borrowRate: { ...current.borrowRate, ...patch },
       }),
       options,
     );
@@ -691,48 +692,32 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
                 <button
                   type="button"
                   className="flex w-full items-center gap-2 text-left text-sm font-semibold"
-                  onClick={() => setShowUtilization(!showUtilization)}
+                  onClick={() => setShowBorrowRate(!showBorrowRate)}
                 >
-                  {showUtilization ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-                  Utilization Alerts
+                  {showBorrowRate ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                  Borrow Rate Alerts
                 </button>
-                {showUtilization ? (
+                {showBorrowRate ? (
                   <div className="mt-3 grid gap-3">
                     <label className="flex items-center gap-2 text-sm">
                       <input
                         type="checkbox"
-                        checked={config.utilization.enabled}
+                        checked={config.borrowRate.enabled}
                         onChange={() =>
-                          updateUtilization(
-                            { enabled: !config.utilization.enabled },
+                          updateBorrowRate(
+                            { enabled: !config.borrowRate.enabled },
                             { persist: true },
                           )
                         }
                         className="accent-primary"
                       />
-                      Enable utilization alerts
+                      Enable borrow rate alerts
                     </label>
 
-                    <label className="grid gap-1.5 text-sm">
-                      <span className="text-muted-foreground">Default threshold (%)</span>
-                      <Input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="1"
-                        value={Math.round(config.utilization.defaultThreshold * 100)}
-                        onChange={(e) =>
-                          updateUtilization({ defaultThreshold: Number(e.target.value) / 100 })
-                        }
-                        onBlur={(e) =>
-                          updateUtilization(
-                            { defaultThreshold: Number(e.target.value) / 100 },
-                            { persist: true },
-                          )
-                        }
-                        className="w-[100px]"
-                      />
-                    </label>
+                    <p className="text-xs text-muted-foreground">
+                      Alerts when a loan&apos;s weighted borrow rate crosses{' '}
+                      <b>{(BORROW_RATE_ALERT_THRESHOLD * 100).toFixed(2)}%</b>.
+                    </p>
 
                     <label className="grid gap-1.5 text-sm">
                       <span className="text-muted-foreground">Alert cooldown (minutes)</span>
@@ -740,12 +725,12 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
                         type="number"
                         min="1"
                         step="1"
-                        value={Math.round(config.utilization.cooldownMs / 60_000)}
+                        value={Math.round(config.borrowRate.cooldownMs / 60_000)}
                         onChange={(e) =>
-                          updateUtilization({ cooldownMs: Number(e.target.value) * 60_000 })
+                          updateBorrowRate({ cooldownMs: Number(e.target.value) * 60_000 })
                         }
                         onBlur={(e) =>
-                          updateUtilization(
+                          updateBorrowRate(
                             { cooldownMs: Number(e.target.value) * 60_000 },
                             { persist: true },
                           )


### PR DESCRIPTION
## Summary
- Removes the noisy 90% market-utilization alert and replaces it with a per-loan **borrow-rate alert** that fires when the loan's weighted borrow rate crosses **4.5%** (hardcoded `BORROW_RATE_ALERT_THRESHOLD`).
- Same hysteresis and cooldown semantics as before (high → normalized), but keyed per loan instead of per borrowed asset, so messages are higher-signal and lower-volume.
- Settings panel renamed to "Borrow Rate Alerts" with just an enable toggle and cooldown — threshold is fixed for now.
- Reserve telemetry, the dashboard "Utilization %" column, and the utilization curve chart are unchanged.

Config migration is silent: the old `utilization` block in persisted JSON is ignored and `borrowRate` defaults are seeded.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] `yarn test` (112/112 pass; rewrote 5 monitor alert cases + schema/storage/response/runtime tests)
- [ ] Smoke-test Telegram `/status` and trigger a borrow-rate crossing in dev to confirm the new alert formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)