### PR TITLE
fix(dash): Drive Monitoring Checklist card from live data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
     selectedVault,
   });
 
-  const { watchdog: watchdogConfig } = useWatchdogConfig();
+  const watchdogState = useWatchdogConfig();
 
   const computed = useMemo(() => computeLoanMetrics(selectedLoan), [selectedLoan]);
   const portfolio = useMemo(() => {
@@ -203,7 +203,7 @@ export default function App() {
                         reserveTelemetry={selectedReserveTelemetry}
                         reserveTelemetryError={reserveTelemetryError}
                         selectedLoan={selectedLoan}
-                        watchdog={watchdogConfig}
+                        watchdogState={watchdogState}
                       />
                     </>
                   )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from './components/dashboard/privacyStorage';
 import { usePortfolioMonitor } from './hooks/usePortfolioMonitor';
 import { usePositionDetailsData } from './hooks/usePositionDetailsData';
+import { useWatchdogConfig } from './hooks/useWatchdogConfig';
 
 export default function App() {
   const {
@@ -58,6 +59,8 @@ export default function App() {
     selectedLoan,
     selectedVault,
   });
+
+  const { watchdog: watchdogConfig } = useWatchdogConfig();
 
   const computed = useMemo(() => computeLoanMetrics(selectedLoan), [selectedLoan]);
   const portfolio = useMemo(() => {
@@ -200,6 +203,7 @@ export default function App() {
                         reserveTelemetry={selectedReserveTelemetry}
                         reserveTelemetryError={reserveTelemetryError}
                         selectedLoan={selectedLoan}
+                        watchdog={watchdogConfig}
                       />
                     </>
                   )}

--- a/src/components/dashboard/PositionDetails.tsx
+++ b/src/components/dashboard/PositionDetails.tsx
@@ -1,14 +1,9 @@
 import { AlertTriangle, Info, ShieldCheck } from 'lucide-react';
-import {
-  clamp,
-  healthLabel,
-  type Computed,
-  type LoanPosition,
-  type WatchdogConfig,
-} from '@aave-monitor/core';
+import { clamp, healthLabel, type Computed, type LoanPosition } from '@aave-monitor/core';
 import { LoanPositionChartsCard, type BorrowRateSample } from '../ReserveCharts';
 import type { InterestSnapshot } from '../../api/aaveMonitor';
-import { Badge } from '../ui/badge';
+import type { WatchdogConfigState } from '../../hooks/useWatchdogConfig';
+import { Badge, type BadgeVariant } from '../ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Separator } from '../ui/separator';
 import { fmtAmount, fmtPct, fmtUSD, toBadgeVariant } from '../../lib/formatters';
@@ -34,7 +29,8 @@ const STABLECOIN_SYMBOLS = new Set([
   'USDS',
 ]);
 
-type ChecklistStatus = { ok: boolean; detail: string };
+type ChecklistState = 'ok' | 'watch' | 'unknown';
+type ChecklistStatus = { state: ChecklistState; detail: string };
 
 function isStablecoin(symbol: string): boolean {
   return STABLECOIN_SYMBOLS.has(symbol.toUpperCase());
@@ -44,7 +40,7 @@ function evaluateRatesDrift(history: BorrowRateSample[], computed: Computed): Ch
   const cutoff = Date.now() - SEVEN_DAYS_MS;
   const recent = history.filter((s) => Date.parse(s.timestamp) >= cutoff);
   if (recent.length < 2) {
-    return { ok: true, detail: 'Insufficient history to assess drift' };
+    return { state: 'unknown', detail: 'Insufficient history to assess drift' };
   }
   const avg = recent.reduce((sum, s) => sum + s.variableBorrowRate, 0) / recent.length;
   const latest = recent.at(-1)?.variableBorrowRate ?? computed.rBorrow;
@@ -54,21 +50,21 @@ function evaluateRatesDrift(history: BorrowRateSample[], computed: Computed): Ch
   const deltaStr = `${sign}${absPp.toFixed(1)}pp`;
   if (absPp >= RATES_DRIFT_PP_THRESHOLD) {
     return {
-      ok: false,
+      state: 'watch',
       detail: `Borrow APY ${fmtPct(latest)} — drifted ${deltaStr} vs 7-day avg`,
     };
   }
   return {
-    ok: true,
+    state: 'ok',
     detail: `Borrow APY ${fmtPct(latest)}, ${deltaStr} vs 7-day avg`,
   };
 }
 
 function evaluateDepeg(loan: LoanPosition | null): ChecklistStatus {
-  if (!loan) return { ok: true, detail: 'No position selected' };
+  if (!loan) return { state: 'unknown', detail: 'No position selected' };
   const assets = [...loan.borrowed, ...loan.supplied].filter((a) => isStablecoin(a.symbol));
   if (assets.length === 0) {
-    return { ok: true, detail: 'No stablecoins in this position' };
+    return { state: 'ok', detail: 'No stablecoins in this position' };
   }
   let worst = assets[0]!;
   let worstDev = Math.abs((worst.usdPrice ?? 1) - 1);
@@ -83,11 +79,11 @@ function evaluateDepeg(loan: LoanPosition | null): ChecklistStatus {
   const signedPct = ((worstPrice - 1) * 100).toFixed(2);
   if (worstDev > DEPEG_THRESHOLD) {
     return {
-      ok: false,
+      state: 'watch',
       detail: `${worst.symbol} at $${worstPrice.toFixed(4)} (${signedPct}% off peg)`,
     };
   }
-  return { ok: true, detail: `All stables within 0.5% of $1 (${assets.length} checked)` };
+  return { state: 'ok', detail: `All stables within 0.5% of $1 (${assets.length} checked)` };
 }
 
 function evaluateOracleMarket(
@@ -95,42 +91,49 @@ function evaluateOracleMarket(
   loan: LoanPosition | null,
 ): ChecklistStatus {
   if (loan?.morphoMarketParams) {
-    return { ok: true, detail: 'Telemetry not available for Morpho markets' };
+    return { state: 'unknown', detail: 'Telemetry not available for Morpho markets' };
   }
   if (!telemetry) {
-    return { ok: true, detail: 'Reserve telemetry unavailable' };
+    return { state: 'unknown', detail: 'Reserve telemetry unavailable' };
   }
   const utilPct = fmtPct(telemetry.utilizationRate);
   if (telemetry.utilizationRate >= ORACLE_UTILIZATION_WATCH) {
     return {
-      ok: false,
+      state: 'watch',
       detail: `${telemetry.symbol} reserve util ${utilPct} — withdrawals may slip`,
     };
   }
-  return { ok: true, detail: `${telemetry.symbol} reserve util ${utilPct}` };
+  return { state: 'ok', detail: `${telemetry.symbol} reserve util ${utilPct}` };
 }
 
 function evaluateAutomation(
-  watchdog: WatchdogConfig | null,
+  watchdogState: WatchdogConfigState,
   loan: LoanPosition | null,
 ): ChecklistStatus {
+  const { watchdog, loading, error } = watchdogState;
+  if (loading && !watchdog) {
+    return { state: 'unknown', detail: 'Loading watchdog status…' };
+  }
+  if (error) {
+    return { state: 'unknown', detail: `Watchdog status unavailable: ${error}` };
+  }
   if (!watchdog) {
-    return { ok: true, detail: 'Loading watchdog status…' };
+    return { state: 'unknown', detail: 'Watchdog config not returned by server' };
   }
   if (!watchdog.enabled) {
-    return { ok: false, detail: 'Watchdog disabled' };
+    return { state: 'watch', detail: 'Watchdog disabled' };
   }
   const isMorpho = !!loan?.morphoMarketParams;
   const rescue = isMorpho ? watchdog.morphoRescueContract : watchdog.rescueContract;
   const protocolLabel = isMorpho ? 'Morpho' : 'Aave';
   if (!rescue || rescue === ZERO_ADDRESS) {
-    return { ok: false, detail: `No rescue contract configured for ${protocolLabel}` };
+    return { state: 'watch', detail: `No rescue contract configured for ${protocolLabel}` };
   }
   if (!(watchdog.triggerHF > 0) || !(watchdog.targetHF > 0)) {
-    return { ok: false, detail: 'Watchdog trigger/target HF not configured' };
+    return { state: 'watch', detail: 'Watchdog trigger/target HF not configured' };
   }
   return {
-    ok: true,
+    state: 'ok',
     detail: `Watchdog on (${protocolLabel}) — trigger HF ${watchdog.triggerHF.toFixed(
       2,
     )}, target ${watchdog.targetHF.toFixed(2)}`,
@@ -159,7 +162,7 @@ export function PositionDetailsSection({
   reserveTelemetry,
   reserveTelemetryError,
   selectedLoan,
-  watchdog,
+  watchdogState,
 }: {
   hideSensitiveValues: boolean;
   borrowRateHistory: BorrowRateSample[];
@@ -169,7 +172,7 @@ export function PositionDetailsSection({
   reserveTelemetry: ReserveTelemetry | null;
   reserveTelemetryError: string;
   selectedLoan: LoanPosition | null;
-  watchdog: WatchdogConfig | null;
+  watchdogState: WatchdogConfigState;
 }) {
   return (
     <section className="mt-2 grid gap-4 [grid-template-columns:minmax(320px,0.95fr)_minmax(0,2fr)] max-[980px]:grid-cols-1">
@@ -202,7 +205,7 @@ export function PositionDetailsSection({
           borrowRateHistory={borrowRateHistory}
           reserveTelemetry={reserveTelemetry}
           selectedLoan={selectedLoan}
-          watchdog={watchdog}
+          watchdogState={watchdogState}
         />
         <SensitivityCard hideSensitiveValues={hideSensitiveValues} computed={computed} />
       </div>
@@ -497,26 +500,38 @@ function MonitoringChecklistCard({
   borrowRateHistory,
   reserveTelemetry,
   selectedLoan,
-  watchdog,
+  watchdogState,
 }: {
   computed: Computed;
   borrowRateHistory: BorrowRateSample[];
   reserveTelemetry: ReserveTelemetry | null;
   selectedLoan: LoanPosition | null;
-  watchdog: WatchdogConfig | null;
+  watchdogState: WatchdogConfigState;
 }) {
   const ratesDrift = evaluateRatesDrift(borrowRateHistory, computed);
   const depeg = evaluateDepeg(selectedLoan);
   const oracleMarket = evaluateOracleMarket(reserveTelemetry, selectedLoan);
-  const automation = evaluateAutomation(watchdog, selectedLoan);
-  const hfDetail = computed.alertHF
-    ? `Health factor ${computed.healthFactor.toFixed(2)} — below safe threshold`
-    : `Health factor ${
-        Number.isFinite(computed.healthFactor) ? computed.healthFactor.toFixed(2) : '∞'
-      } — comfortably above 1.0`;
-  const ltvDetail = computed.alertLTV
-    ? `LTV ${fmtPct(computed.ltv)} near liquidation threshold ${fmtPct(computed.lt)}`
-    : `LTV ${fmtPct(computed.ltv)} vs liquidation threshold ${fmtPct(computed.lt)}`;
+  const automation = evaluateAutomation(watchdogState, selectedLoan);
+  const hfStatus: ChecklistStatus = computed.alertHF
+    ? {
+        state: 'watch',
+        detail: `Health factor ${computed.healthFactor.toFixed(2)} — below safe threshold`,
+      }
+    : {
+        state: 'ok',
+        detail: `Health factor ${
+          Number.isFinite(computed.healthFactor) ? computed.healthFactor.toFixed(2) : '∞'
+        } — comfortably above 1.0`,
+      };
+  const ltvStatus: ChecklistStatus = computed.alertLTV
+    ? {
+        state: 'watch',
+        detail: `LTV ${fmtPct(computed.ltv)} near liquidation threshold ${fmtPct(computed.lt)}`,
+      }
+    : {
+        state: 'ok',
+        detail: `LTV ${fmtPct(computed.ltv)} vs liquidation threshold ${fmtPct(computed.lt)}`,
+      };
 
   return (
     <Card>
@@ -524,12 +539,12 @@ function MonitoringChecklistCard({
         <CardTitle>Monitoring Checklist</CardTitle>
       </CardHeader>
       <CardContent className="grid-cols-3 max-[980px]:grid-cols-1">
-        <ChecklistItem title="Health Factor" ok={!computed.alertHF} detail={hfDetail} />
-        <ChecklistItem title="LTV vs LT" ok={!computed.alertLTV} detail={ltvDetail} />
-        <ChecklistItem title="Rates drift" ok={ratesDrift.ok} detail={ratesDrift.detail} />
-        <ChecklistItem title="Stablecoin depeg" ok={depeg.ok} detail={depeg.detail} />
-        <ChecklistItem title="Oracle / market" ok={oracleMarket.ok} detail={oracleMarket.detail} />
-        <ChecklistItem title="Automation" ok={automation.ok} detail={automation.detail} />
+        <ChecklistItem title="Health Factor" status={hfStatus} />
+        <ChecklistItem title="LTV vs LT" status={ltvStatus} />
+        <ChecklistItem title="Rates drift" status={ratesDrift} />
+        <ChecklistItem title="Stablecoin depeg" status={depeg} />
+        <ChecklistItem title="Oracle / market" status={oracleMarket} />
+        <ChecklistItem title="Automation" status={automation} />
       </CardContent>
     </Card>
   );
@@ -615,14 +630,21 @@ function Row({
   );
 }
 
-function ChecklistItem({ title, detail, ok }: { title: string; detail: string; ok: boolean }) {
+const CHECKLIST_BADGE: Record<ChecklistState, { variant: BadgeVariant; label: string }> = {
+  ok: { variant: 'positive', label: 'OK' },
+  watch: { variant: 'destructive', label: 'Watch' },
+  unknown: { variant: 'default', label: 'N/A' },
+};
+
+function ChecklistItem({ title, status }: { title: string; status: ChecklistStatus }) {
+  const badge = CHECKLIST_BADGE[status.state];
   return (
     <article className="rounded-lg border border-border bg-accent p-3">
       <div className="flex items-center justify-between gap-2.5">
         <h3 className="text-sm font-medium">{title}</h3>
-        <Badge variant={ok ? 'positive' : 'destructive'}>{ok ? 'OK' : 'Watch'}</Badge>
+        <Badge variant={badge.variant}>{badge.label}</Badge>
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{status.detail}</p>
     </article>
   );
 }

--- a/src/components/dashboard/PositionDetails.tsx
+++ b/src/components/dashboard/PositionDetails.tsx
@@ -1,5 +1,11 @@
 import { AlertTriangle, Info, ShieldCheck } from 'lucide-react';
-import { clamp, healthLabel, type Computed, type LoanPosition } from '@aave-monitor/core';
+import {
+  clamp,
+  healthLabel,
+  type Computed,
+  type LoanPosition,
+  type WatchdogConfig,
+} from '@aave-monitor/core';
 import { LoanPositionChartsCard, type BorrowRateSample } from '../ReserveCharts';
 import type { InterestSnapshot } from '../../api/aaveMonitor';
 import { Badge } from '../ui/badge';
@@ -8,6 +14,128 @@ import { Separator } from '../ui/separator';
 import { fmtAmount, fmtPct, fmtUSD, toBadgeVariant } from '../../lib/formatters';
 import { type ReserveTelemetry } from '@aave-monitor/core';
 import { SensitiveValue } from './privacy';
+
+const RATES_DRIFT_PP_THRESHOLD = 2.0;
+const DEPEG_THRESHOLD = 0.005;
+const ORACLE_UTILIZATION_WATCH = 0.95;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const STABLECOIN_SYMBOLS = new Set([
+  'USDC',
+  'USDT',
+  'DAI',
+  'LUSD',
+  'FRAX',
+  'USDE',
+  'SUSDE',
+  'CRVUSD',
+  'GHO',
+  'PYUSD',
+  'USDS',
+]);
+
+type ChecklistStatus = { ok: boolean; detail: string };
+
+function isStablecoin(symbol: string): boolean {
+  return STABLECOIN_SYMBOLS.has(symbol.toUpperCase());
+}
+
+function evaluateRatesDrift(history: BorrowRateSample[], computed: Computed): ChecklistStatus {
+  const cutoff = Date.now() - SEVEN_DAYS_MS;
+  const recent = history.filter((s) => Date.parse(s.timestamp) >= cutoff);
+  if (recent.length < 2) {
+    return { ok: true, detail: 'Insufficient history to assess drift' };
+  }
+  const avg = recent.reduce((sum, s) => sum + s.variableBorrowRate, 0) / recent.length;
+  const latest = recent.at(-1)?.variableBorrowRate ?? computed.rBorrow;
+  const deltaPp = (latest - avg) * 100;
+  const absPp = Math.abs(deltaPp);
+  const sign = deltaPp >= 0 ? '+' : '−';
+  const deltaStr = `${sign}${absPp.toFixed(1)}pp`;
+  if (absPp >= RATES_DRIFT_PP_THRESHOLD) {
+    return {
+      ok: false,
+      detail: `Borrow APY ${fmtPct(latest)} — drifted ${deltaStr} vs 7-day avg`,
+    };
+  }
+  return {
+    ok: true,
+    detail: `Borrow APY ${fmtPct(latest)}, ${deltaStr} vs 7-day avg`,
+  };
+}
+
+function evaluateDepeg(loan: LoanPosition | null): ChecklistStatus {
+  if (!loan) return { ok: true, detail: 'No position selected' };
+  const assets = [...loan.borrowed, ...loan.supplied].filter((a) => isStablecoin(a.symbol));
+  if (assets.length === 0) {
+    return { ok: true, detail: 'No stablecoins in this position' };
+  }
+  let worst = assets[0]!;
+  let worstDev = Math.abs((worst.usdPrice ?? 1) - 1);
+  for (const a of assets) {
+    const dev = Math.abs((a.usdPrice ?? 1) - 1);
+    if (dev > worstDev) {
+      worst = a;
+      worstDev = dev;
+    }
+  }
+  const worstPrice = worst.usdPrice ?? 1;
+  const signedPct = ((worstPrice - 1) * 100).toFixed(2);
+  if (worstDev > DEPEG_THRESHOLD) {
+    return {
+      ok: false,
+      detail: `${worst.symbol} at $${worstPrice.toFixed(4)} (${signedPct}% off peg)`,
+    };
+  }
+  return { ok: true, detail: `All stables within 0.5% of $1 (${assets.length} checked)` };
+}
+
+function evaluateOracleMarket(
+  telemetry: ReserveTelemetry | null,
+  loan: LoanPosition | null,
+): ChecklistStatus {
+  if (loan?.morphoMarketParams) {
+    return { ok: true, detail: 'Telemetry not available for Morpho markets' };
+  }
+  if (!telemetry) {
+    return { ok: true, detail: 'Reserve telemetry unavailable' };
+  }
+  const utilPct = fmtPct(telemetry.utilizationRate);
+  if (telemetry.utilizationRate >= ORACLE_UTILIZATION_WATCH) {
+    return {
+      ok: false,
+      detail: `${telemetry.symbol} reserve util ${utilPct} — withdrawals may slip`,
+    };
+  }
+  return { ok: true, detail: `${telemetry.symbol} reserve util ${utilPct}` };
+}
+
+function evaluateAutomation(
+  watchdog: WatchdogConfig | null,
+  loan: LoanPosition | null,
+): ChecklistStatus {
+  if (!watchdog) {
+    return { ok: true, detail: 'Loading watchdog status…' };
+  }
+  if (!watchdog.enabled) {
+    return { ok: false, detail: 'Watchdog disabled' };
+  }
+  const isMorpho = !!loan?.morphoMarketParams;
+  const rescue = isMorpho ? watchdog.morphoRescueContract : watchdog.rescueContract;
+  const protocolLabel = isMorpho ? 'Morpho' : 'Aave';
+  if (!rescue || rescue === ZERO_ADDRESS) {
+    return { ok: false, detail: `No rescue contract configured for ${protocolLabel}` };
+  }
+  if (!(watchdog.triggerHF > 0) || !(watchdog.targetHF > 0)) {
+    return { ok: false, detail: 'Watchdog trigger/target HF not configured' };
+  }
+  return {
+    ok: true,
+    detail: `Watchdog on (${protocolLabel}) — trigger HF ${watchdog.triggerHF.toFixed(
+      2,
+    )}, target ${watchdog.targetHF.toFixed(2)}`,
+  };
+}
 
 export function SelectedLoanLabel({ loan }: { loan: LoanPosition | null }) {
   if (!loan) return null;
@@ -31,6 +159,7 @@ export function PositionDetailsSection({
   reserveTelemetry,
   reserveTelemetryError,
   selectedLoan,
+  watchdog,
 }: {
   hideSensitiveValues: boolean;
   borrowRateHistory: BorrowRateSample[];
@@ -40,6 +169,7 @@ export function PositionDetailsSection({
   reserveTelemetry: ReserveTelemetry | null;
   reserveTelemetryError: string;
   selectedLoan: LoanPosition | null;
+  watchdog: WatchdogConfig | null;
 }) {
   return (
     <section className="mt-2 grid gap-4 [grid-template-columns:minmax(320px,0.95fr)_minmax(0,2fr)] max-[980px]:grid-cols-1">
@@ -67,7 +197,13 @@ export function PositionDetailsSection({
           computed={computed}
           selectedLoan={selectedLoan}
         />
-        <MonitoringChecklistCard computed={computed} />
+        <MonitoringChecklistCard
+          computed={computed}
+          borrowRateHistory={borrowRateHistory}
+          reserveTelemetry={reserveTelemetry}
+          selectedLoan={selectedLoan}
+          watchdog={watchdog}
+        />
         <SensitivityCard hideSensitiveValues={hideSensitiveValues} computed={computed} />
       </div>
     </section>
@@ -356,43 +492,44 @@ function MetricsGrid({
   );
 }
 
-function MonitoringChecklistCard({ computed }: { computed: Computed }) {
+function MonitoringChecklistCard({
+  computed,
+  borrowRateHistory,
+  reserveTelemetry,
+  selectedLoan,
+  watchdog,
+}: {
+  computed: Computed;
+  borrowRateHistory: BorrowRateSample[];
+  reserveTelemetry: ReserveTelemetry | null;
+  selectedLoan: LoanPosition | null;
+  watchdog: WatchdogConfig | null;
+}) {
+  const ratesDrift = evaluateRatesDrift(borrowRateHistory, computed);
+  const depeg = evaluateDepeg(selectedLoan);
+  const oracleMarket = evaluateOracleMarket(reserveTelemetry, selectedLoan);
+  const automation = evaluateAutomation(watchdog, selectedLoan);
+  const hfDetail = computed.alertHF
+    ? `Health factor ${computed.healthFactor.toFixed(2)} — below safe threshold`
+    : `Health factor ${
+        Number.isFinite(computed.healthFactor) ? computed.healthFactor.toFixed(2) : '∞'
+      } — comfortably above 1.0`;
+  const ltvDetail = computed.alertLTV
+    ? `LTV ${fmtPct(computed.ltv)} near liquidation threshold ${fmtPct(computed.lt)}`
+    : `LTV ${fmtPct(computed.ltv)} vs liquidation threshold ${fmtPct(computed.lt)}`;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Monitoring Checklist</CardTitle>
       </CardHeader>
       <CardContent className="grid-cols-3 max-[980px]:grid-cols-1">
-        <ChecklistItem
-          title="Health Factor"
-          ok={!computed.alertHF}
-          detail="Keep HF comfortably above 1.0; many traders target 1.7-2.5+."
-        />
-        <ChecklistItem
-          title="LTV vs LT"
-          ok={!computed.alertLTV}
-          detail="As LTV approaches liquidation threshold, small price moves can liquidate you."
-        />
-        <ChecklistItem
-          title="Rates drift"
-          ok
-          detail="Borrow/supply APYs are variable; net carry can flip quickly during volatility."
-        />
-        <ChecklistItem
-          title="Stablecoin depeg"
-          ok
-          detail="USDC/USDT are usually close to $1, but depegs can distort debt value."
-        />
-        <ChecklistItem
-          title="Oracle / market"
-          ok
-          detail="Liquidations depend on oracle price; liquidity + slippage matters in crashes."
-        />
-        <ChecklistItem
-          title="Automation"
-          ok
-          detail="Consider alerts (HF, price, LTV) and an emergency delever playbook."
-        />
+        <ChecklistItem title="Health Factor" ok={!computed.alertHF} detail={hfDetail} />
+        <ChecklistItem title="LTV vs LT" ok={!computed.alertLTV} detail={ltvDetail} />
+        <ChecklistItem title="Rates drift" ok={ratesDrift.ok} detail={ratesDrift.detail} />
+        <ChecklistItem title="Stablecoin depeg" ok={depeg.ok} detail={depeg.detail} />
+        <ChecklistItem title="Oracle / market" ok={oracleMarket.ok} detail={oracleMarket.detail} />
+        <ChecklistItem title="Automation" ok={automation.ok} detail={automation.detail} />
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/PositionDetails.tsx
+++ b/src/components/dashboard/PositionDetails.tsx
@@ -9,136 +9,16 @@ import { Separator } from '../ui/separator';
 import { fmtAmount, fmtPct, fmtUSD, toBadgeVariant } from '../../lib/formatters';
 import { type ReserveTelemetry } from '@aave-monitor/core';
 import { SensitiveValue } from './privacy';
-
-const RATES_DRIFT_PP_THRESHOLD = 2.0;
-const DEPEG_THRESHOLD = 0.005;
-const ORACLE_UTILIZATION_WATCH = 0.95;
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-const STABLECOIN_SYMBOLS = new Set([
-  'USDC',
-  'USDT',
-  'DAI',
-  'LUSD',
-  'FRAX',
-  'USDE',
-  'SUSDE',
-  'CRVUSD',
-  'GHO',
-  'PYUSD',
-  'USDS',
-]);
-
-type ChecklistState = 'ok' | 'watch' | 'unknown';
-type ChecklistStatus = { state: ChecklistState; detail: string };
-
-function isStablecoin(symbol: string): boolean {
-  return STABLECOIN_SYMBOLS.has(symbol.toUpperCase());
-}
-
-function evaluateRatesDrift(history: BorrowRateSample[], computed: Computed): ChecklistStatus {
-  const cutoff = Date.now() - SEVEN_DAYS_MS;
-  const recent = history.filter((s) => Date.parse(s.timestamp) >= cutoff);
-  if (recent.length < 2) {
-    return { state: 'unknown', detail: 'Insufficient history to assess drift' };
-  }
-  const avg = recent.reduce((sum, s) => sum + s.variableBorrowRate, 0) / recent.length;
-  const latest = recent.at(-1)?.variableBorrowRate ?? computed.rBorrow;
-  const deltaPp = (latest - avg) * 100;
-  const absPp = Math.abs(deltaPp);
-  const sign = deltaPp >= 0 ? '+' : '−';
-  const deltaStr = `${sign}${absPp.toFixed(1)}pp`;
-  if (absPp >= RATES_DRIFT_PP_THRESHOLD) {
-    return {
-      state: 'watch',
-      detail: `Borrow APY ${fmtPct(latest)} — drifted ${deltaStr} vs 7-day avg`,
-    };
-  }
-  return {
-    state: 'ok',
-    detail: `Borrow APY ${fmtPct(latest)}, ${deltaStr} vs 7-day avg`,
-  };
-}
-
-function evaluateDepeg(loan: LoanPosition | null): ChecklistStatus {
-  if (!loan) return { state: 'unknown', detail: 'No position selected' };
-  const assets = [...loan.borrowed, ...loan.supplied].filter((a) => isStablecoin(a.symbol));
-  if (assets.length === 0) {
-    return { state: 'ok', detail: 'No stablecoins in this position' };
-  }
-  let worst = assets[0]!;
-  let worstDev = Math.abs((worst.usdPrice ?? 1) - 1);
-  for (const a of assets) {
-    const dev = Math.abs((a.usdPrice ?? 1) - 1);
-    if (dev > worstDev) {
-      worst = a;
-      worstDev = dev;
-    }
-  }
-  const worstPrice = worst.usdPrice ?? 1;
-  const signedPct = ((worstPrice - 1) * 100).toFixed(2);
-  if (worstDev > DEPEG_THRESHOLD) {
-    return {
-      state: 'watch',
-      detail: `${worst.symbol} at $${worstPrice.toFixed(4)} (${signedPct}% off peg)`,
-    };
-  }
-  return { state: 'ok', detail: `All stables within 0.5% of $1 (${assets.length} checked)` };
-}
-
-function evaluateOracleMarket(
-  telemetry: ReserveTelemetry | null,
-  loan: LoanPosition | null,
-): ChecklistStatus {
-  if (loan?.morphoMarketParams) {
-    return { state: 'unknown', detail: 'Telemetry not available for Morpho markets' };
-  }
-  if (!telemetry) {
-    return { state: 'unknown', detail: 'Reserve telemetry unavailable' };
-  }
-  const utilPct = fmtPct(telemetry.utilizationRate);
-  if (telemetry.utilizationRate >= ORACLE_UTILIZATION_WATCH) {
-    return {
-      state: 'watch',
-      detail: `${telemetry.symbol} reserve util ${utilPct} — withdrawals may slip`,
-    };
-  }
-  return { state: 'ok', detail: `${telemetry.symbol} reserve util ${utilPct}` };
-}
-
-function evaluateAutomation(
-  watchdogState: WatchdogConfigState,
-  loan: LoanPosition | null,
-): ChecklistStatus {
-  const { watchdog, loading, error } = watchdogState;
-  if (loading && !watchdog) {
-    return { state: 'unknown', detail: 'Loading watchdog status…' };
-  }
-  if (error) {
-    return { state: 'unknown', detail: `Watchdog status unavailable: ${error}` };
-  }
-  if (!watchdog) {
-    return { state: 'unknown', detail: 'Watchdog config not returned by server' };
-  }
-  if (!watchdog.enabled) {
-    return { state: 'watch', detail: 'Watchdog disabled' };
-  }
-  const isMorpho = !!loan?.morphoMarketParams;
-  const rescue = isMorpho ? watchdog.morphoRescueContract : watchdog.rescueContract;
-  const protocolLabel = isMorpho ? 'Morpho' : 'Aave';
-  if (!rescue || rescue === ZERO_ADDRESS) {
-    return { state: 'watch', detail: `No rescue contract configured for ${protocolLabel}` };
-  }
-  if (!(watchdog.triggerHF > 0) || !(watchdog.targetHF > 0)) {
-    return { state: 'watch', detail: 'Watchdog trigger/target HF not configured' };
-  }
-  return {
-    state: 'ok',
-    detail: `Watchdog on (${protocolLabel}) — trigger HF ${watchdog.triggerHF.toFixed(
-      2,
-    )}, target ${watchdog.targetHF.toFixed(2)}`,
-  };
-}
+import {
+  evaluateAutomation,
+  evaluateDepeg,
+  evaluateHealthFactor,
+  evaluateLtv,
+  evaluateOracleMarket,
+  evaluateRatesDrift,
+  type ChecklistState,
+  type ChecklistStatus,
+} from './monitoringChecklist';
 
 export function SelectedLoanLabel({ loan }: { loan: LoanPosition | null }) {
   if (!loan) return null;
@@ -508,30 +388,12 @@ function MonitoringChecklistCard({
   selectedLoan: LoanPosition | null;
   watchdogState: WatchdogConfigState;
 }) {
+  const hfStatus = evaluateHealthFactor(computed);
+  const ltvStatus = evaluateLtv(computed);
   const ratesDrift = evaluateRatesDrift(borrowRateHistory, computed);
   const depeg = evaluateDepeg(selectedLoan);
   const oracleMarket = evaluateOracleMarket(reserveTelemetry, selectedLoan);
   const automation = evaluateAutomation(watchdogState, selectedLoan);
-  const hfStatus: ChecklistStatus = computed.alertHF
-    ? {
-        state: 'watch',
-        detail: `Health factor ${computed.healthFactor.toFixed(2)} — below safe threshold`,
-      }
-    : {
-        state: 'ok',
-        detail: `Health factor ${
-          Number.isFinite(computed.healthFactor) ? computed.healthFactor.toFixed(2) : '∞'
-        } — comfortably above 1.0`,
-      };
-  const ltvStatus: ChecklistStatus = computed.alertLTV
-    ? {
-        state: 'watch',
-        detail: `LTV ${fmtPct(computed.ltv)} near liquidation threshold ${fmtPct(computed.lt)}`,
-      }
-    : {
-        state: 'ok',
-        detail: `LTV ${fmtPct(computed.ltv)} vs liquidation threshold ${fmtPct(computed.lt)}`,
-      };
 
   return (
     <Card>

--- a/src/components/dashboard/monitoringChecklist.ts
+++ b/src/components/dashboard/monitoringChecklist.ts
@@ -1,0 +1,154 @@
+import type { Computed, LoanPosition, ReserveTelemetry } from '@aave-monitor/core';
+import type { BorrowRateSample } from '../ReserveCharts';
+import type { WatchdogConfigState } from '../../hooks/useWatchdogConfig';
+import { fmtPct } from '../../lib/formatters';
+
+const RATES_DRIFT_PP_THRESHOLD = 2.0;
+const DEPEG_THRESHOLD = 0.005;
+const ORACLE_UTILIZATION_WATCH = 0.95;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const STABLECOIN_SYMBOLS = new Set([
+  'USDC',
+  'USDT',
+  'DAI',
+  'LUSD',
+  'FRAX',
+  'USDE',
+  'SUSDE',
+  'CRVUSD',
+  'GHO',
+  'PYUSD',
+  'USDS',
+]);
+
+export type ChecklistState = 'ok' | 'watch' | 'unknown';
+export type ChecklistStatus = { state: ChecklistState; detail: string };
+
+function isStablecoin(symbol: string): boolean {
+  return STABLECOIN_SYMBOLS.has(symbol.toUpperCase());
+}
+
+export function evaluateHealthFactor(computed: Computed): ChecklistStatus {
+  if (computed.alertHF) {
+    return {
+      state: 'watch',
+      detail: `Health factor ${computed.healthFactor.toFixed(2)} — below safe threshold`,
+    };
+  }
+  const hf = Number.isFinite(computed.healthFactor) ? computed.healthFactor.toFixed(2) : '∞';
+  return { state: 'ok', detail: `Health factor ${hf} — comfortably above 1.0` };
+}
+
+export function evaluateLtv(computed: Computed): ChecklistStatus {
+  const ltv = fmtPct(computed.ltv);
+  const lt = fmtPct(computed.lt);
+  if (computed.alertLTV) {
+    return { state: 'watch', detail: `LTV ${ltv} near liquidation threshold ${lt}` };
+  }
+  return { state: 'ok', detail: `LTV ${ltv} vs liquidation threshold ${lt}` };
+}
+
+export function evaluateRatesDrift(
+  history: BorrowRateSample[],
+  computed: Computed,
+): ChecklistStatus {
+  const cutoff = Date.now() - SEVEN_DAYS_MS;
+  const recent = history.filter((s) => Date.parse(s.timestamp) >= cutoff);
+  if (recent.length < 2) {
+    return { state: 'unknown', detail: 'Insufficient history to assess drift' };
+  }
+  const avg = recent.reduce((sum, s) => sum + s.variableBorrowRate, 0) / recent.length;
+  const latest = recent.at(-1)?.variableBorrowRate ?? computed.rBorrow;
+  const deltaPp = (latest - avg) * 100;
+  const absPp = Math.abs(deltaPp);
+  const sign = deltaPp >= 0 ? '+' : '−';
+  const deltaStr = `${sign}${absPp.toFixed(1)}pp`;
+  if (absPp >= RATES_DRIFT_PP_THRESHOLD) {
+    return {
+      state: 'watch',
+      detail: `Borrow APY ${fmtPct(latest)} — drifted ${deltaStr} vs 7-day avg`,
+    };
+  }
+  return { state: 'ok', detail: `Borrow APY ${fmtPct(latest)}, ${deltaStr} vs 7-day avg` };
+}
+
+export function evaluateDepeg(loan: LoanPosition | null): ChecklistStatus {
+  if (!loan) return { state: 'unknown', detail: 'No position selected' };
+  const assets = [...loan.borrowed, ...loan.supplied].filter((a) => isStablecoin(a.symbol));
+  if (assets.length === 0) {
+    return { state: 'ok', detail: 'No stablecoins in this position' };
+  }
+  let worst = assets[0]!;
+  let worstDev = Math.abs((worst.usdPrice ?? 1) - 1);
+  for (const a of assets) {
+    const dev = Math.abs((a.usdPrice ?? 1) - 1);
+    if (dev > worstDev) {
+      worst = a;
+      worstDev = dev;
+    }
+  }
+  const worstPrice = worst.usdPrice ?? 1;
+  const signedPct = ((worstPrice - 1) * 100).toFixed(2);
+  if (worstDev > DEPEG_THRESHOLD) {
+    return {
+      state: 'watch',
+      detail: `${worst.symbol} at $${worstPrice.toFixed(4)} (${signedPct}% off peg)`,
+    };
+  }
+  return { state: 'ok', detail: `All stables within 0.5% of $1 (${assets.length} checked)` };
+}
+
+export function evaluateOracleMarket(
+  telemetry: ReserveTelemetry | null,
+  loan: LoanPosition | null,
+): ChecklistStatus {
+  if (loan?.morphoMarketParams) {
+    return { state: 'unknown', detail: 'Telemetry not available for Morpho markets' };
+  }
+  if (!telemetry) {
+    return { state: 'unknown', detail: 'Reserve telemetry unavailable' };
+  }
+  const utilPct = fmtPct(telemetry.utilizationRate);
+  if (telemetry.utilizationRate >= ORACLE_UTILIZATION_WATCH) {
+    return {
+      state: 'watch',
+      detail: `${telemetry.symbol} reserve util ${utilPct} — withdrawals may slip`,
+    };
+  }
+  return { state: 'ok', detail: `${telemetry.symbol} reserve util ${utilPct}` };
+}
+
+export function evaluateAutomation(
+  watchdogState: WatchdogConfigState,
+  loan: LoanPosition | null,
+): ChecklistStatus {
+  const { watchdog, loading, error } = watchdogState;
+  if (loading && !watchdog) {
+    return { state: 'unknown', detail: 'Loading watchdog status…' };
+  }
+  if (error) {
+    return { state: 'unknown', detail: `Watchdog status unavailable: ${error}` };
+  }
+  if (!watchdog) {
+    return { state: 'unknown', detail: 'Watchdog config not returned by server' };
+  }
+  if (!watchdog.enabled) {
+    return { state: 'watch', detail: 'Watchdog disabled' };
+  }
+  const isMorpho = !!loan?.morphoMarketParams;
+  const rescue = isMorpho ? watchdog.morphoRescueContract : watchdog.rescueContract;
+  const protocolLabel = isMorpho ? 'Morpho' : 'Aave';
+  if (!rescue || rescue === ZERO_ADDRESS) {
+    return { state: 'watch', detail: `No rescue contract configured for ${protocolLabel}` };
+  }
+  if (!(watchdog.triggerHF > 0) || !(watchdog.targetHF > 0)) {
+    return { state: 'watch', detail: 'Watchdog trigger/target HF not configured' };
+  }
+  return {
+    state: 'ok',
+    detail: `Watchdog on (${protocolLabel}) — trigger HF ${watchdog.triggerHF.toFixed(
+      2,
+    )}, target ${watchdog.targetHF.toFixed(2)}`,
+  };
+}

--- a/src/hooks/useWatchdogConfig.ts
+++ b/src/hooks/useWatchdogConfig.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import type { WatchdogConfig } from '@aave-monitor/core';
+
+type State = {
+  watchdog: WatchdogConfig | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useWatchdogConfig(): State {
+  const [state, setState] = useState<State>({ watchdog: null, loading: true, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch('/api/config');
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const body = (await response.json()) as { watchdog?: WatchdogConfig };
+        if (cancelled) return;
+        setState({ watchdog: body.watchdog ?? null, loading: false, error: null });
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Failed to load watchdog config';
+        setState({ watchdog: null, loading: false, error: message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/src/hooks/useWatchdogConfig.ts
+++ b/src/hooks/useWatchdogConfig.ts
@@ -1,34 +1,54 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WatchdogConfig } from '@aave-monitor/core';
 
-type State = {
+export type WatchdogConfigState = {
   watchdog: WatchdogConfig | null;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 };
 
-export function useWatchdogConfig(): State {
-  const [state, setState] = useState<State>({ watchdog: null, loading: true, error: null });
+export function useWatchdogConfig(): WatchdogConfigState {
+  const [watchdog, setWatchdog] = useState<WatchdogConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const response = await fetch('/api/config');
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const body = (await response.json()) as { watchdog?: WatchdogConfig };
-        if (cancelled) return;
-        setState({ watchdog: body.watchdog ?? null, loading: false, error: null });
-      } catch (err) {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : 'Failed to load watchdog config';
-        setState({ watchdog: null, loading: false, error: message });
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/config');
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (!contentType.includes('application/json')) {
+        throw new Error('Config API returned non-JSON response');
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
+      const body = (await response.json()) as { watchdog?: WatchdogConfig };
+      if (cancelledRef.current) return;
+      setWatchdog(body.watchdog ?? null);
+      setError(null);
+    } catch (err) {
+      if (cancelledRef.current) return;
+      const message = err instanceof Error ? err.message : 'Failed to load watchdog config';
+      setWatchdog(null);
+      setError(message);
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
   }, []);
 
-  return state;
+  useEffect(() => {
+    cancelledRef.current = false;
+    void fetchConfig(); // eslint-disable-line react-hooks/set-state-in-effect -- fetch-on-mount
+    const onFocus = () => {
+      void fetchConfig();
+    };
+    window.addEventListener('focus', onFocus);
+    return () => {
+      cancelledRef.current = true;
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [fetchConfig]);
+
+  return { watchdog, loading, error, refetch: fetchConfig };
 }


### PR DESCRIPTION
## Summary
- The Monitoring Checklist card on the loan detail page had four items (Rates drift, Stablecoin depeg, Oracle / market, Automation) hardcoded to `ok` with static blurbs — they always rendered a green "OK", giving false reassurance.
- Each item is now driven by data already flowing through `PositionDetailsSection` (plus a small new `/api/config` fetch for the watchdog state), and the detail line shows the live value instead of generic text.
- HF and LTV items also got dynamic detail strings showing their current numbers.

### Evaluator logic
- **Rates drift** — 7-day trailing average of `BorrowRateSample.variableBorrowRate`; Watch when |latest − avg| ≥ 2pp.
- **Stablecoin depeg** — scans `borrowed[]` + `supplied[]` for known stables (USDC/USDT/DAI/LUSD/FRAX/USDe/sUSDe/crvUSD/GHO/PYUSD/USDS); Watch if any deviation from \$1 > 0.5%.
- **Oracle / market** — Aave reserve telemetry: Watch when `utilizationRate ≥ 95%`. For Morpho loans, shows "Telemetry not available for Morpho markets" (not a misleading OK).
- **Automation** — new `useWatchdogConfig` hook fetches `GET /api/config`; Watch when watchdog disabled, rescue contract missing for the loan's protocol, or trigger/target HF unconfigured.

Thresholds live as named constants at the top of `PositionDetails.tsx` for easy tuning.

## Test plan
- [x] `yarn typecheck && yarn lint && yarn format:check` pass (confirmed locally)
- [x] `yarn dev` + `yarn dev:server` against a wallet with both Aave and Morpho loans; verify each item shows live values and OK/Watch flips as expected
- [ ] Toggle watchdog enabled/disabled and clear/set rescue contract via Server Settings; confirm Automation flips with a specific cause in the detail
- [x] Confirm Morpho loans show the "telemetry not available" detail on Oracle / market

🤖 Generated with [Claude Code](https://claude.com/claude-code)