### PR TITLE
feat(watchdog): layer-0 pre-rescue Morpho vault withdrawal

### DIFF
--- a/docs/watchdog-user-manual.md
+++ b/docs/watchdog-user-manual.md
@@ -124,3 +124,64 @@ Live:
 - Pre-approve debt/loan tokens from monitored wallet to rescue contract(s).
 - Keep `maxRepayAmount` small during rollout.
 - Monitor Telegram alerts and `/api/watchdog/status` for recent repay activity.
+
+## Layer 0: Pre-rescue Morpho Vault Withdrawal
+
+If the operator's debt-token funds are parked in a Morpho ERC-4626 vault (e.g.
+Gauntlet USDC Prime) rather than sitting idle in the wallet, the regular rescue
+path would log "no available USDC" even when the operator has plenty of capital
+to defend the loan. Layer 0 closes that gap by pre-emptively withdrawing from the
+vault into the wallet _before_ HF reaches the layer-1 trigger.
+
+### How it works
+
+- Layer 0 fires only when HF is in the buffer band `[triggerHF, preRescueTriggerHF)`.
+- It computes the debt repay amount that would be needed to reach `targetHF` (capped
+  at `maxVaultWithdrawAmount`), checks the wallet for existing balance, and only
+  withdraws the shortfall.
+- The vault is selected automatically by matching the loan's debt-token address;
+  if multiple vaults match, the one with the largest balance wins.
+- Withdrawn assets are sent directly to the monitored wallet via the ERC-4626
+  `withdraw(assets, owner, owner)` call. The helper contract never custodies
+  funds.
+- A separate cooldown key (`-prerescue`) prevents repeated withdrawals.
+- If HF recovers above `preRescueTriggerHF`, the withdrawn funds simply stay in
+  the wallet; the operator can redeposit them manually.
+- If HF crosses `triggerHF`, the existing layer-1 rescue runs in the next poll
+  cycle, consuming the now-funded wallet balance — no change to layer-1 code.
+
+### Configuration
+
+- `preRescueEnabled` (default `false`)
+- `preRescueTriggerHF` (default `1.7`)
+- `vaultWithdrawContract` (required when `preRescueEnabled=true`) — address of
+  `MorphoVaultWithdrawV1`
+- `maxVaultWithdrawAmount` (default `500`) — per-action cap in the debt token
+
+Validation: `preRescueTriggerHF > triggerHF` and `vaultWithdrawContract` must be
+a valid address when `preRescueEnabled` is true.
+
+Environment overrides:
+
+- `WATCHDOG_PRE_TRIGGER_HF`
+- `WATCHDOG_VAULT_WITHDRAW_CONTRACT`
+- `WATCHDOG_MAX_VAULT_WITHDRAW_AMOUNT`
+
+### On-chain requirements
+
+- Deploy `MorphoVaultWithdrawV1(owner=monitoredWallet, executor=botAddress)`.
+- Call `setSupportedVault(vaultAddress, true)` from the owner wallet for each
+  Morpho vault you want to draw from (one contract supports multiple vaults).
+- From the monitored wallet, approve the vault's share token (the vault is the
+  ERC-4626 itself): `vault.approve(vaultWithdrawContract, type(uint256).max)`.
+- The executor key may differ from the monitored wallet (same model as the
+  existing rescue contracts).
+
+### Log entries
+
+Layer-0 outcomes appear in `/api/watchdog/status` with new action types:
+
+- `vault-withdraw` — live withdrawal succeeded; `txHash` and `vaultAddress` set
+- `vault-withdraw-dry-run` — dry-run preview entry
+- `skipped` — buffer-band conditions not met (wallet already funded, no matching
+  vault, cooldown, etc.)

--- a/packages/aave-core/src/constants.ts
+++ b/packages/aave-core/src/constants.ts
@@ -104,4 +104,8 @@ export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
   rescueContract: '',
   morphoRescueContract: '',
   maxGasGwei: 50,
+  preRescueEnabled: false,
+  preRescueTriggerHF: 1.7,
+  vaultWithdrawContract: '',
+  maxVaultWithdrawAmount: 500,
 };

--- a/packages/aave-core/src/types.ts
+++ b/packages/aave-core/src/types.ts
@@ -19,6 +19,14 @@ export type WatchdogConfig = {
   rescueContract: string;
   morphoRescueContract: string;
   maxGasGwei: number;
+  /** Layer-0 (pre-rescue) Morpho vault withdrawal. */
+  preRescueEnabled: boolean;
+  /** HF at or above which layer-0 stays idle; layer-0 runs in [triggerHF, preRescueTriggerHF). */
+  preRescueTriggerHF: number;
+  /** MorphoVaultWithdrawV1 contract address. */
+  vaultWithdrawContract: string;
+  /** Per-loan, debt-token-denominated cap on a single layer-0 withdrawal. */
+  maxVaultWithdrawAmount: number;
 };
 
 export type RawUserReserve = {

--- a/packages/rescue-contract/src/MorphoVaultWithdrawV1.sol
+++ b/packages/rescue-contract/src/MorphoVaultWithdrawV1.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+interface IERC4626 {
+    function asset() external view returns (address);
+    function maxWithdraw(address owner) external view returns (uint256);
+    function withdraw(uint256 assets, address receiver, address owner)
+        external
+        returns (uint256 shares);
+}
+
+contract MorphoVaultWithdrawV1 {
+    struct WithdrawParams {
+        address user;
+        address vault;
+        uint256 assets;
+        uint256 deadline;
+    }
+
+    error NotOwner();
+    error NotExecutor();
+    error DeadlineExpired();
+    error VaultNotSupported();
+    error InvalidAddress();
+    error InvalidAmount();
+    error UserNotOwner();
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event ExecutorUpdated(address indexed previousExecutor, address indexed newExecutor);
+    event VaultSupportUpdated(address indexed vault, bool enabled);
+    event VaultWithdrawExecuted(
+        address indexed user, address indexed vault, uint256 assets, uint256 shares
+    );
+
+    address public owner;
+    address public executor;
+
+    mapping(address => bool) public supportedVault;
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    modifier onlyExecutor() {
+        if (msg.sender != executor) revert NotExecutor();
+        _;
+    }
+
+    constructor(address owner_, address executor_) {
+        if (owner_ == address(0) || executor_ == address(0)) revert InvalidAddress();
+        owner = owner_;
+        executor = executor_;
+        emit OwnershipTransferred(address(0), owner_);
+        emit ExecutorUpdated(address(0), executor_);
+    }
+
+    function setOwner(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert InvalidAddress();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function setExecutor(address newExecutor) external onlyOwner {
+        if (newExecutor == address(0)) revert InvalidAddress();
+        emit ExecutorUpdated(executor, newExecutor);
+        executor = newExecutor;
+    }
+
+    function setSupportedVault(address vault, bool enabled) external onlyOwner {
+        if (vault == address(0)) revert InvalidAddress();
+        supportedVault[vault] = enabled;
+        emit VaultSupportUpdated(vault, enabled);
+    }
+
+    /// @notice Redeem `assets` units of the vault's underlying from `user`'s shares
+    /// and send them directly to `user`. The contract never custodies funds; it
+    /// only orchestrates an ERC-4626 withdraw on behalf of the owner.
+    /// Requires `user` to have approved this contract on the vault's share token.
+    function withdraw(WithdrawParams calldata params) external onlyExecutor {
+        if (params.user != owner) revert UserNotOwner();
+        if (params.deadline < block.timestamp) revert DeadlineExpired();
+        if (params.assets == 0) revert InvalidAmount();
+        if (!supportedVault[params.vault]) revert VaultNotSupported();
+
+        uint256 shares = IERC4626(params.vault).withdraw(params.assets, params.user, params.user);
+
+        emit VaultWithdrawExecuted(params.user, params.vault, params.assets, shares);
+    }
+
+    function previewMaxWithdraw(address vault, address user) external view returns (uint256) {
+        return IERC4626(vault).maxWithdraw(user);
+    }
+}

--- a/packages/rescue-contract/test/MorphoVaultWithdrawV1.t.sol
+++ b/packages/rescue-contract/test/MorphoVaultWithdrawV1.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {MorphoVaultWithdrawV1} from "../src/MorphoVaultWithdrawV1.sol";
+
+contract MockUSDC {
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+/// @dev Minimal ERC-4626-ish vault used for testing the withdraw helper. It
+///      requires the helper to be approved on `shares` to spend on behalf of
+///      `owner`, and pays out underlying directly to `receiver`.
+contract MockVault {
+    MockUSDC public immutable underlying;
+
+    mapping(address => uint256) public shares;
+    mapping(address => mapping(address => uint256)) public shareAllowance;
+    uint256 public maxWithdrawOverride;
+    bool public withdrawShouldRevert;
+
+    constructor(address underlying_) {
+        underlying = MockUSDC(underlying_);
+    }
+
+    function depositForOwner(address owner, uint256 assets) external {
+        underlying.mint(address(this), assets);
+        shares[owner] += assets; // 1:1 for simplicity
+    }
+
+    function approveShares(address spender, uint256 amount) external {
+        shareAllowance[msg.sender][spender] = amount;
+    }
+
+    function setMaxWithdraw(uint256 value) external {
+        maxWithdrawOverride = value;
+    }
+
+    function setWithdrawShouldRevert(bool value) external {
+        withdrawShouldRevert = value;
+    }
+
+    function maxWithdraw(address owner) external view returns (uint256) {
+        if (maxWithdrawOverride != 0) return maxWithdrawOverride;
+        return shares[owner];
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner)
+        external
+        returns (uint256)
+    {
+        require(!withdrawShouldRevert, "vault: withdraw disabled");
+        if (msg.sender != owner) {
+            uint256 allowed = shareAllowance[owner][msg.sender];
+            require(allowed >= assets, "vault: insufficient share allowance");
+            shareAllowance[owner][msg.sender] = allowed - assets;
+        }
+        require(shares[owner] >= assets, "vault: insufficient shares");
+        shares[owner] -= assets;
+        require(underlying.transfer(receiver, assets), "vault: transfer failed");
+        return assets;
+    }
+}
+
+contract MorphoVaultWithdrawV1Test is Test {
+    MockUSDC internal usdc;
+    MockVault internal vault;
+    MorphoVaultWithdrawV1 internal helper;
+
+    address internal owner = address(0xA11CE);
+    address internal executor = address(0xB0B);
+    address internal stranger = address(0xCAFE);
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        vault = new MockVault(address(usdc));
+        helper = new MorphoVaultWithdrawV1(owner, executor);
+
+        vault.depositForOwner(owner, 1_000e6);
+        vm.prank(owner);
+        vault.approveShares(address(helper), type(uint256).max);
+
+        vm.prank(owner);
+        helper.setSupportedVault(address(vault), true);
+    }
+
+    function _params(uint256 assets, uint256 deadline)
+        internal
+        view
+        returns (MorphoVaultWithdrawV1.WithdrawParams memory)
+    {
+        return MorphoVaultWithdrawV1.WithdrawParams({
+            user: owner,
+            vault: address(vault),
+            assets: assets,
+            deadline: deadline
+        });
+    }
+
+    function test_constructorRejectsZeroAddress() public {
+        vm.expectRevert(MorphoVaultWithdrawV1.InvalidAddress.selector);
+        new MorphoVaultWithdrawV1(address(0), executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.InvalidAddress.selector);
+        new MorphoVaultWithdrawV1(owner, address(0));
+    }
+
+    function test_withdrawHappyPath() public {
+        vm.prank(executor);
+        helper.withdraw(_params(200e6, block.timestamp + 60));
+
+        assertEq(usdc.balanceOf(owner), 200e6, "owner should receive underlying");
+        assertEq(vault.shares(owner), 800e6, "shares debited");
+        assertEq(usdc.balanceOf(address(helper)), 0, "helper holds no funds");
+    }
+
+    function test_onlyExecutorCanWithdraw() public {
+        vm.prank(stranger);
+        vm.expectRevert(MorphoVaultWithdrawV1.NotExecutor.selector);
+        helper.withdraw(_params(100e6, block.timestamp + 60));
+    }
+
+    function test_userMustEqualOwner() public {
+        MorphoVaultWithdrawV1.WithdrawParams memory p = _params(100e6, block.timestamp + 60);
+        p.user = stranger;
+        vm.prank(executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.UserNotOwner.selector);
+        helper.withdraw(p);
+    }
+
+    function test_deadlineEnforced() public {
+        vm.warp(1_000);
+        vm.prank(executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.DeadlineExpired.selector);
+        helper.withdraw(_params(100e6, 999));
+    }
+
+    function test_zeroAmountReverts() public {
+        vm.prank(executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.InvalidAmount.selector);
+        helper.withdraw(_params(0, block.timestamp + 60));
+    }
+
+    function test_unsupportedVaultReverts() public {
+        vm.prank(owner);
+        helper.setSupportedVault(address(vault), false);
+        vm.prank(executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.VaultNotSupported.selector);
+        helper.withdraw(_params(100e6, block.timestamp + 60));
+    }
+
+    function test_setSupportedVaultOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(MorphoVaultWithdrawV1.NotOwner.selector);
+        helper.setSupportedVault(address(vault), false);
+    }
+
+    function test_setExecutorOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(MorphoVaultWithdrawV1.NotOwner.selector);
+        helper.setExecutor(address(0xDEAD));
+    }
+
+    function test_rotateExecutor() public {
+        address newExecutor = address(0xDEAD);
+        vm.prank(owner);
+        helper.setExecutor(newExecutor);
+
+        vm.prank(executor);
+        vm.expectRevert(MorphoVaultWithdrawV1.NotExecutor.selector);
+        helper.withdraw(_params(50e6, block.timestamp + 60));
+
+        vm.prank(newExecutor);
+        helper.withdraw(_params(50e6, block.timestamp + 60));
+        assertEq(usdc.balanceOf(owner), 50e6);
+    }
+
+    function test_previewMaxWithdrawReflectsVault() public {
+        assertEq(helper.previewMaxWithdraw(address(vault), owner), 1_000e6);
+        vault.setMaxWithdraw(123e6);
+        assertEq(helper.previewMaxWithdraw(address(vault), owner), 123e6);
+    }
+
+    function test_withdrawPropagatesVaultRevert() public {
+        vault.setWithdrawShouldRevert(true);
+        vm.prank(executor);
+        vm.expectRevert(bytes("vault: withdraw disabled"));
+        helper.withdraw(_params(100e6, block.timestamp + 60));
+    }
+}

--- a/packages/server/src/configSchema.ts
+++ b/packages/server/src/configSchema.ts
@@ -15,6 +15,10 @@ const partialWatchdogConfigSchema = z
     rescueContract: z.string(),
     morphoRescueContract: z.string(),
     maxGasGwei: z.number().positive(),
+    preRescueEnabled: z.boolean(),
+    preRescueTriggerHF: z.number().positive(),
+    vaultWithdrawContract: z.string(),
+    maxVaultWithdrawAmount: z.number().positive(),
   })
   .partial();
 

--- a/packages/server/src/monitor.ts
+++ b/packages/server/src/monitor.ts
@@ -544,7 +544,7 @@ export class Monitor {
 
     // Watchdog evaluation pass — runs after alerts so notifications always go out first
     for (const loan of loans) {
-      await this.watchdog.evaluate(loan, address);
+      await this.watchdog.evaluate(loan, address, morphoVaults);
     }
 
     // Cumulative-interest snapshots for Morpho positions. Recorded every poll so

--- a/packages/server/src/runtime.ts
+++ b/packages/server/src/runtime.ts
@@ -48,7 +48,7 @@ export function validateWatchdogThresholds(
     return 'watchdog requires at least one valid rescue contract when enabled';
   }
 
-  if (merged.preRescueTriggerHF <= merged.triggerHF) {
+  if (merged.preRescueEnabled && merged.preRescueTriggerHF <= merged.triggerHF) {
     return 'watchdog.preRescueTriggerHF must be greater than watchdog.triggerHF';
   }
   if (merged.maxVaultWithdrawAmount <= 0) {

--- a/packages/server/src/runtime.ts
+++ b/packages/server/src/runtime.ts
@@ -11,6 +11,9 @@ type WatchdogStatusSummary = {
   aaveRescueContract: string;
   morphoRescueContract: string;
   recentActions: number;
+  preRescueEnabled: boolean;
+  preRescueTriggerHF: number;
+  vaultWithdrawContract: string;
 };
 
 export function shouldRunMonitor(config: AlertConfig): boolean {
@@ -45,6 +48,20 @@ export function validateWatchdogThresholds(
     return 'watchdog requires at least one valid rescue contract when enabled';
   }
 
+  if (merged.preRescueTriggerHF <= merged.triggerHF) {
+    return 'watchdog.preRescueTriggerHF must be greater than watchdog.triggerHF';
+  }
+  if (merged.maxVaultWithdrawAmount <= 0) {
+    return 'watchdog.maxVaultWithdrawAmount must be greater than 0';
+  }
+  const hasValidVaultContract = /^0x[a-fA-F0-9]{40}$/.test(merged.vaultWithdrawContract);
+  if (merged.vaultWithdrawContract && !hasValidVaultContract) {
+    return 'watchdog.vaultWithdrawContract must be a valid Ethereum address when set';
+  }
+  if (merged.preRescueEnabled && !hasValidVaultContract) {
+    return 'watchdog.preRescueEnabled requires a valid vaultWithdrawContract';
+  }
+
   return null;
 }
 
@@ -64,6 +81,9 @@ export function formatWatchdogStatusMessage(
     `Min resulting HF: <b>${summary.minResultingHF}</b>`,
     `Aave rescue contract: <b>${summary.aaveRescueContract || 'Not set'}</b>`,
     `Morpho rescue contract: <b>${summary.morphoRescueContract || 'Not set'}</b>`,
+    `Pre-rescue: <b>${summary.preRescueEnabled ? 'Enabled' : 'Disabled'}</b>`,
+    `Pre-rescue trigger HF: <b>${summary.preRescueTriggerHF}</b>`,
+    `Vault withdraw contract: <b>${summary.vaultWithdrawContract || 'Not set'}</b>`,
     `Total actions logged: ${summary.recentActions}`,
   ];
 

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -84,6 +84,17 @@ function applyWatchdogEnvOverrides(watchdog: WatchdogConfig): void {
 
   const morphoRescueContract = process.env['WATCHDOG_MORPHO_RESCUE_CONTRACT']?.trim();
   if (morphoRescueContract) watchdog.morphoRescueContract = morphoRescueContract;
+
+  const preRescueTriggerHF = parseEnvFloat('WATCHDOG_PRE_TRIGGER_HF');
+  if (preRescueTriggerHF !== undefined) watchdog.preRescueTriggerHF = preRescueTriggerHF;
+
+  const vaultWithdrawContract = process.env['WATCHDOG_VAULT_WITHDRAW_CONTRACT']?.trim();
+  if (vaultWithdrawContract) watchdog.vaultWithdrawContract = vaultWithdrawContract;
+
+  const maxVaultWithdrawAmount = parseEnvFloat('WATCHDOG_MAX_VAULT_WITHDRAW_AMOUNT');
+  if (maxVaultWithdrawAmount !== undefined) {
+    watchdog.maxVaultWithdrawAmount = maxVaultWithdrawAmount;
+  }
 }
 
 function mergeWatchdogConfig(config: Partial<WatchdogConfig> | undefined): WatchdogConfig {

--- a/packages/server/src/watchdog.ts
+++ b/packages/server/src/watchdog.ts
@@ -28,6 +28,10 @@ const VAULT_WITHDRAW_INTERFACE = new Interface([
   'function withdraw((address user,address vault,uint256 assets,uint256 deadline) params)',
 ]);
 
+const ERC4626_INTERFACE = new Interface([
+  'function maxWithdraw(address owner) view returns (uint256)',
+]);
+
 const MIN_ETH_FOR_GAS = 0.005;
 const TELEGRAM_MESSAGE_LIMIT = 3900;
 export type WatchdogLogEntry = {
@@ -591,40 +595,32 @@ export class Watchdog {
       : (amount: bigint) =>
           this.previewResultingHf(provider, rescueContract, walletAddress, debtToken, amount);
 
-    let neededRaw: bigint;
-    let walletBalanceRaw: bigint;
-    try {
-      const targetHFWad = this.toWad(config.targetHF);
-      const maxVaultWithdrawRaw = parseUnits(
-        config.maxVaultWithdrawAmount.toFixed(debtDecimals),
-        debtDecimals,
-      );
-      walletBalanceRaw = await this.getTokenBalance(provider, debtToken, walletAddress);
+    // 1. Find candidate vaults (matching the debt token) and query each one's
+    //    user-specific maxWithdraw on-chain. We can't trust Morpho API
+    //    `totalAssets` as a proxy for "withdrawable by this user" — it's a
+    //    vault-wide total, not per-owner, and ignores liquidity / share-balance
+    //    constraints. Pick the candidate with the largest withdrawable amount.
+    const debtTokenLower = debtToken.toLowerCase();
+    const candidates = vaults.filter((v) => v.asset.address.toLowerCase() === debtTokenLower);
 
-      // Compute how much debt repay would be required to reach targetHF, capped
-      // by maxVaultWithdraw. We don't fold in wallet balance here — that becomes
-      // the "do we even need to withdraw?" check below.
-      const computed = await this.findRequiredAmountRawGeneric(
-        previewFn,
-        targetHFWad,
-        maxVaultWithdrawRaw,
-      );
-      if (computed === null || computed <= 0n) {
-        this.addLog({
-          timestamp: now,
-          loanId: loan.id,
-          wallet: walletAddress,
-          protocol,
-          action: 'skipped',
-          reason: `Pre-rescue: ${this.toFormattedAmount(maxVaultWithdrawRaw, debtDecimals).toFixed(2)} ${debtSymbol} not enough to reach target HF`,
-          healthFactor,
-          repayAmount: 0,
-          repayAssetSymbol: debtSymbol,
-          projectedHF: healthFactor,
-        });
-        return;
-      }
-      neededRaw = computed;
+    let walletBalanceRaw: bigint;
+    let vaultMaxWithdrawals: { vault: MorphoVaultPosition; maxWithdrawRaw: bigint }[];
+    try {
+      const [balance, maxWithdrawals] = await Promise.all([
+        this.getTokenBalance(provider, debtToken, walletAddress),
+        Promise.all(
+          candidates.map(async (vault) => ({
+            vault,
+            maxWithdrawRaw: await this.getVaultMaxWithdraw(
+              provider,
+              vault.vaultAddress,
+              walletAddress,
+            ),
+          })),
+        ),
+      ]);
+      walletBalanceRaw = balance;
+      vaultMaxWithdrawals = maxWithdrawals;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       this.addLog({
@@ -642,6 +638,82 @@ export class Watchdog {
       return;
     }
 
+    const bestVault = vaultMaxWithdrawals
+      .filter((entry) => entry.maxWithdrawRaw > 0n)
+      .reduce<
+        { vault: MorphoVaultPosition; maxWithdrawRaw: bigint } | undefined
+      >((best, entry) => (!best || entry.maxWithdrawRaw > best.maxWithdrawRaw ? entry : best), undefined);
+
+    if (!bestVault) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue: no Morpho vault with withdrawable ${debtSymbol} found`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    // 2. Compute total repay capacity (wallet + vault), capped by both
+    //    maxVaultWithdrawAmount (per-action vault cap) and maxRepayAmount
+    //    (layer-1's eventual cap — withdrawing more than this can't be used
+    //    by the follow-up rescue and is wasted gas / slippage).
+    const maxVaultWithdrawRaw = parseUnits(
+      config.maxVaultWithdrawAmount.toFixed(debtDecimals),
+      debtDecimals,
+    );
+    const maxRepayRaw = parseUnits(config.maxRepayAmount.toFixed(debtDecimals), debtDecimals);
+    const usableVaultRaw = minBigInt(bestVault.maxWithdrawRaw, maxVaultWithdrawRaw);
+    const totalCapacityRaw = minBigInt(walletBalanceRaw + usableVaultRaw, maxRepayRaw);
+
+    let neededRaw: bigint;
+    try {
+      const targetHFWad = this.toWad(config.targetHF);
+      const computed = await this.findRequiredAmountRawGeneric(
+        previewFn,
+        targetHFWad,
+        totalCapacityRaw,
+      );
+      if (computed === null || computed <= 0n) {
+        this.addLog({
+          timestamp: now,
+          loanId: loan.id,
+          wallet: walletAddress,
+          protocol,
+          action: 'skipped',
+          reason: `Pre-rescue: ${this.toFormattedAmount(totalCapacityRaw, debtDecimals).toFixed(2)} ${debtSymbol} (wallet + vault, capped) not enough to reach target HF`,
+          healthFactor,
+          repayAmount: 0,
+          repayAssetSymbol: debtSymbol,
+          projectedHF: healthFactor,
+        });
+        return;
+      }
+      neededRaw = computed;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue HF preview failed: ${message}`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    // 3. If wallet already covers needed repay, layer 1 doesn't need help.
     if (walletBalanceRaw >= neededRaw) {
       this.addLog({
         timestamp: now,
@@ -658,40 +730,13 @@ export class Watchdog {
       return;
     }
 
-    const debtTokenLower = debtToken.toLowerCase();
-    const matchingVault = vaults
-      .filter((v) => v.asset.address.toLowerCase() === debtTokenLower && v.totalAssets > 0)
-      .reduce<
-        MorphoVaultPosition | undefined
-      >((best, v) => (!best || v.totalAssets > best.totalAssets ? v : best), undefined);
-
-    if (!matchingVault) {
-      this.addLog({
-        timestamp: now,
-        loanId: loan.id,
-        wallet: walletAddress,
-        protocol,
-        action: 'skipped',
-        reason: `Pre-rescue: no Morpho vault holding ${debtSymbol} found`,
-        healthFactor,
-        repayAmount: 0,
-        repayAssetSymbol: debtSymbol,
-        projectedHF: healthFactor,
-      });
-      return;
-    }
-
+    // 4. Withdraw only the shortfall, bounded by what the vault will actually
+    //    allow this user to pull and by maxVaultWithdrawAmount.
     const shortfallRaw = neededRaw - walletBalanceRaw;
-    const vaultAssetsRaw = parseUnits(
-      matchingVault.totalAssets.toFixed(debtDecimals),
-      debtDecimals,
-    );
-    const maxVaultWithdrawRaw = parseUnits(
-      config.maxVaultWithdrawAmount.toFixed(debtDecimals),
-      debtDecimals,
-    );
-    const withdrawRaw = minBigInt(shortfallRaw, vaultAssetsRaw, maxVaultWithdrawRaw);
+    const withdrawRaw = minBigInt(shortfallRaw, usableVaultRaw);
     if (withdrawRaw <= 0n) return;
+
+    const matchingVault = bestVault.vault;
 
     const withdrawAmount = this.toFormattedAmount(withdrawRaw, debtDecimals);
 
@@ -999,6 +1044,17 @@ export class Watchdog {
     const result = await provider.call({ to: token, data });
     const [balance] = ERC20_INTERFACE.decodeFunctionResult('balanceOf', result);
     return BigInt(balance);
+  }
+
+  private async getVaultMaxWithdraw(
+    provider: JsonRpcProvider,
+    vault: string,
+    owner: string,
+  ): Promise<bigint> {
+    const data = ERC4626_INTERFACE.encodeFunctionData('maxWithdraw', [owner]);
+    const result = await provider.call({ to: vault, data });
+    const [maxAssets] = ERC4626_INTERFACE.decodeFunctionResult('maxWithdraw', result);
+    return BigInt(maxAssets);
   }
 
   private async getTokenAllowance(

--- a/packages/server/src/watchdog.ts
+++ b/packages/server/src/watchdog.ts
@@ -1,4 +1,9 @@
-import { computeLoanMetrics, type LoanPosition, type MorphoMarketParams } from '@aave-monitor/core';
+import {
+  computeLoanMetrics,
+  type LoanPosition,
+  type MorphoMarketParams,
+  type MorphoVaultPosition,
+} from '@aave-monitor/core';
 import { formatUnits, Interface, JsonRpcProvider, parseUnits, Wallet } from 'ethers';
 import type { WatchdogConfig } from './storage.js';
 import type { TelegramClient } from './telegram.js';
@@ -19,6 +24,10 @@ const MORPHO_RESCUE_INTERFACE = new Interface([
   'function previewResultingHf((address loanToken,address collateralToken,address oracle,address irm,uint256 lltv) marketParams, address user, uint256 amount) view returns (uint256)',
 ]);
 
+const VAULT_WITHDRAW_INTERFACE = new Interface([
+  'function withdraw((address user,address vault,uint256 assets,uint256 deadline) params)',
+]);
+
 const MIN_ETH_FOR_GAS = 0.005;
 const TELEGRAM_MESSAGE_LIMIT = 3900;
 export type WatchdogLogEntry = {
@@ -26,13 +35,14 @@ export type WatchdogLogEntry = {
   loanId: string;
   wallet: string;
   protocol: 'aave' | 'morpho';
-  action: 'dry-run' | 'rescue' | 'skipped';
+  action: 'dry-run' | 'rescue' | 'skipped' | 'vault-withdraw' | 'vault-withdraw-dry-run';
   reason: string;
   healthFactor: number;
   repayAmount: number;
   repayAssetSymbol: string;
   projectedHF: number;
   txHash?: string;
+  vaultAddress?: string;
 };
 
 export class Watchdog {
@@ -64,6 +74,9 @@ export class Watchdog {
     aaveRescueContract: string;
     morphoRescueContract: string;
     recentActions: number;
+    preRescueEnabled: boolean;
+    preRescueTriggerHF: number;
+    vaultWithdrawContract: string;
   } {
     const config = this.getConfig();
     return {
@@ -76,10 +89,17 @@ export class Watchdog {
       aaveRescueContract: config.rescueContract,
       morphoRescueContract: config.morphoRescueContract,
       recentActions: this.log.length,
+      preRescueEnabled: config.preRescueEnabled,
+      preRescueTriggerHF: config.preRescueTriggerHF,
+      vaultWithdrawContract: config.vaultWithdrawContract,
     };
   }
 
-  async evaluate(loan: LoanPosition, walletAddress: string): Promise<void> {
+  async evaluate(
+    loan: LoanPosition,
+    walletAddress: string,
+    vaults: MorphoVaultPosition[] = [],
+  ): Promise<void> {
     const isMorpho = loan.marketName.startsWith('morpho_');
     const isAave = loan.marketName.startsWith('proto_');
     if (!isMorpho && !isAave) return;
@@ -92,9 +112,29 @@ export class Watchdog {
     const metrics = computeLoanMetrics(loan);
     const healthFactor = metrics.healthFactor;
     const borrowRate = this.formatBorrowRate(metrics.rBorrow);
-    if (!Number.isFinite(healthFactor) || healthFactor >= config.triggerHF) {
+    if (!Number.isFinite(healthFactor)) return;
+
+    // Layer 0: opportunistic Morpho vault withdrawal in the buffer band
+    // [triggerHF, preRescueTriggerHF). Runs *before* layer 1 so that funds
+    // are already in the wallet by the time HF crosses triggerHF.
+    if (
+      config.preRescueEnabled &&
+      healthFactor >= config.triggerHF &&
+      healthFactor < config.preRescueTriggerHF
+    ) {
+      await this.attemptPreRescueWithdraw(
+        loan,
+        walletAddress,
+        vaults,
+        healthFactor,
+        borrowRate,
+        protocol,
+        isMorpho,
+      );
       return;
     }
+
+    if (healthFactor >= config.triggerHF) return;
 
     // Resolve protocol-specific rescue contract and debt token info.
     // For Aave, pick the borrowed asset with the largest USD value — repaying
@@ -455,6 +495,343 @@ export class Watchdog {
           `Error: ${message}`,
       );
     }
+  }
+
+  private async attemptPreRescueWithdraw(
+    loan: LoanPosition,
+    walletAddress: string,
+    vaults: MorphoVaultPosition[],
+    healthFactor: number,
+    borrowRate: string,
+    protocol: 'aave' | 'morpho',
+    isMorpho: boolean,
+  ): Promise<void> {
+    const config = this.getConfig();
+    const vaultWithdrawContract = config.vaultWithdrawContract.trim();
+    const primaryDebt = isMorpho
+      ? loan.borrowed[0]
+      : loan.borrowed.length > 1
+        ? loan.borrowed.reduce((a, b) => (b.usdValue > a.usdValue ? b : a))
+        : loan.borrowed[0];
+    const debtToken = isMorpho
+      ? (loan.morphoMarketParams?.loanToken ?? primaryDebt?.address)
+      : primaryDebt?.address;
+    const debtDecimals = primaryDebt?.decimals ?? 6;
+    const debtSymbol = primaryDebt?.symbol ?? 'USDC';
+    const morphoParams = isMorpho ? loan.morphoMarketParams : undefined;
+
+    if (!/^0x[a-fA-F0-9]{40}$/.test(vaultWithdrawContract)) {
+      this.addLog({
+        timestamp: Date.now(),
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: 'Invalid or missing vaultWithdrawContract in watchdog config',
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    if (!debtToken) return;
+    if (isMorpho && !morphoParams) return;
+
+    const now = Date.now();
+    const stateKey = `${walletAddress}-${loan.id}-prerescue`;
+    const lastAction = this.cooldowns.get(stateKey) ?? 0;
+    if (now - lastAction < config.cooldownMs) {
+      const remainingMs = config.cooldownMs - (now - lastAction);
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue cooldown active: ${Math.round(remainingMs / 1000)}s remaining`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    const provider = this.getProvider();
+    const rescueContract = isMorpho
+      ? config.morphoRescueContract.trim()
+      : config.rescueContract.trim();
+    if (!/^0x[a-fA-F0-9]{40}$/.test(rescueContract)) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue: invalid ${isMorpho ? 'morphoRescueContract' : 'rescueContract'} (needed for HF preview)`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    const previewFn = isMorpho
+      ? (amount: bigint) =>
+          this.previewResultingHfMorpho(
+            provider,
+            rescueContract,
+            walletAddress,
+            amount,
+            morphoParams!,
+          )
+      : (amount: bigint) =>
+          this.previewResultingHf(provider, rescueContract, walletAddress, debtToken, amount);
+
+    let neededRaw: bigint;
+    let walletBalanceRaw: bigint;
+    try {
+      const targetHFWad = this.toWad(config.targetHF);
+      const maxVaultWithdrawRaw = parseUnits(
+        config.maxVaultWithdrawAmount.toFixed(debtDecimals),
+        debtDecimals,
+      );
+      walletBalanceRaw = await this.getTokenBalance(provider, debtToken, walletAddress);
+
+      // Compute how much debt repay would be required to reach targetHF, capped
+      // by maxVaultWithdraw. We don't fold in wallet balance here — that becomes
+      // the "do we even need to withdraw?" check below.
+      const computed = await this.findRequiredAmountRawGeneric(
+        previewFn,
+        targetHFWad,
+        maxVaultWithdrawRaw,
+      );
+      if (computed === null || computed <= 0n) {
+        this.addLog({
+          timestamp: now,
+          loanId: loan.id,
+          wallet: walletAddress,
+          protocol,
+          action: 'skipped',
+          reason: `Pre-rescue: ${this.toFormattedAmount(maxVaultWithdrawRaw, debtDecimals).toFixed(2)} ${debtSymbol} not enough to reach target HF`,
+          healthFactor,
+          repayAmount: 0,
+          repayAssetSymbol: debtSymbol,
+          projectedHF: healthFactor,
+        });
+        return;
+      }
+      neededRaw = computed;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue on-chain call failed: ${message}`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    if (walletBalanceRaw >= neededRaw) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue: wallet already holds ${this.toFormattedAmount(walletBalanceRaw, debtDecimals).toFixed(2)} ${debtSymbol} (need ${this.toFormattedAmount(neededRaw, debtDecimals).toFixed(2)})`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    const debtTokenLower = debtToken.toLowerCase();
+    const matchingVault = vaults
+      .filter((v) => v.asset.address.toLowerCase() === debtTokenLower && v.totalAssets > 0)
+      .reduce<
+        MorphoVaultPosition | undefined
+      >((best, v) => (!best || v.totalAssets > best.totalAssets ? v : best), undefined);
+
+    if (!matchingVault) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue: no Morpho vault holding ${debtSymbol} found`,
+        healthFactor,
+        repayAmount: 0,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+      });
+      return;
+    }
+
+    const shortfallRaw = neededRaw - walletBalanceRaw;
+    const vaultAssetsRaw = parseUnits(
+      matchingVault.totalAssets.toFixed(debtDecimals),
+      debtDecimals,
+    );
+    const maxVaultWithdrawRaw = parseUnits(
+      config.maxVaultWithdrawAmount.toFixed(debtDecimals),
+      debtDecimals,
+    );
+    const withdrawRaw = minBigInt(shortfallRaw, vaultAssetsRaw, maxVaultWithdrawRaw);
+    if (withdrawRaw <= 0n) return;
+
+    const withdrawAmount = this.toFormattedAmount(withdrawRaw, debtDecimals);
+
+    if (config.dryRun) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'vault-withdraw-dry-run',
+        reason: `Would withdraw ${withdrawAmount.toFixed(2)} ${debtSymbol} from ${matchingVault.vaultName}`,
+        healthFactor,
+        repayAmount: withdrawAmount,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+        vaultAddress: matchingVault.vaultAddress,
+      });
+      this.cooldowns.set(stateKey, now);
+      await this.notify(
+        `🧪 <b>Watchdog Pre-rescue DRY RUN</b>\n\n` +
+          `Loan: ${loan.id} (${loan.marketName})\n` +
+          `HF: <b>${healthFactor.toFixed(4)}</b> (band: ${config.triggerHF}–${config.preRescueTriggerHF})\n` +
+          `Borrow rate: <b>${borrowRate}</b>\n` +
+          `Would withdraw: <b>${withdrawAmount.toFixed(2)} ${debtSymbol}</b>\n` +
+          `From vault: <code>${matchingVault.vaultName}</code>`,
+      );
+      return;
+    }
+
+    if (!this.executorPrivateKey) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: 'Pre-rescue: no executor private key configured',
+        healthFactor,
+        repayAmount: withdrawAmount,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+        vaultAddress: matchingVault.vaultAddress,
+      });
+      return;
+    }
+
+    const gasPriceGwei = await this.getGasPriceGwei(provider);
+    if (gasPriceGwei > config.maxGasGwei) {
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue: gas ${gasPriceGwei.toFixed(1)} gwei exceeds max ${config.maxGasGwei}`,
+        healthFactor,
+        repayAmount: withdrawAmount,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+        vaultAddress: matchingVault.vaultAddress,
+      });
+      return;
+    }
+
+    const deadline = Math.floor(Date.now() / 1000) + config.deadlineSeconds;
+    try {
+      const txHash = await this.submitVaultWithdrawTransaction(
+        walletAddress,
+        vaultWithdrawContract,
+        matchingVault.vaultAddress,
+        withdrawRaw,
+        deadline,
+      );
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'vault-withdraw',
+        reason: `Withdrew ${withdrawAmount.toFixed(2)} ${debtSymbol} from ${matchingVault.vaultName}`,
+        healthFactor,
+        repayAmount: withdrawAmount,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+        txHash,
+        vaultAddress: matchingVault.vaultAddress,
+      });
+      this.cooldowns.set(stateKey, Date.now());
+      await this.notify(
+        `🛟 <b>Watchdog: Pre-rescue vault withdrawal</b>\n\n` +
+          `Loan: ${loan.id} (${loan.marketName})\n` +
+          `HF: <b>${healthFactor.toFixed(4)}</b> (band: ${config.triggerHF}–${config.preRescueTriggerHF})\n` +
+          `Borrow rate: <b>${borrowRate}</b>\n` +
+          `Withdrew: <b>${withdrawAmount.toFixed(2)} ${debtSymbol}</b>\n` +
+          `From vault: <code>${matchingVault.vaultName}</code>\n` +
+          `Tx: <code>${txHash}</code>`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.addLog({
+        timestamp: now,
+        loanId: loan.id,
+        wallet: walletAddress,
+        protocol,
+        action: 'skipped',
+        reason: `Pre-rescue tx failed: ${message}`,
+        healthFactor,
+        repayAmount: withdrawAmount,
+        repayAssetSymbol: debtSymbol,
+        projectedHF: healthFactor,
+        vaultAddress: matchingVault.vaultAddress,
+      });
+      this.cooldowns.set(stateKey, Date.now());
+      await this.notify(
+        `❌ <b>Watchdog: Pre-rescue failed</b>\n\n` +
+          `Loan: ${loan.id} (${loan.marketName})\n` +
+          `Borrow rate: <b>${borrowRate}</b>\n` +
+          `Attempted: <b>${withdrawAmount.toFixed(2)} ${debtSymbol}</b> from ${matchingVault.vaultName}\n` +
+          `Error: ${message}`,
+      );
+    }
+  }
+
+  private async submitVaultWithdrawTransaction(
+    user: string,
+    vaultWithdrawContract: string,
+    vault: string,
+    assetsRaw: bigint,
+    deadline: number,
+  ): Promise<string> {
+    const wallet = this.getWallet();
+    const data = VAULT_WITHDRAW_INTERFACE.encodeFunctionData('withdraw', [
+      { user, vault, assets: assetsRaw, deadline },
+    ]);
+    const tx = await wallet.sendTransaction({ to: vaultWithdrawContract, data });
+    const receipt = await this.waitForReceiptOrReplacement(tx, vaultWithdrawContract, data);
+    if (!receipt || receipt.status === 0) {
+      throw new Error(`Transaction reverted: ${tx.hash}`);
+    }
+    return receipt.hash;
   }
 
   private async findRequiredAmountRawGeneric(

--- a/packages/server/test/watchdog.test.ts
+++ b/packages/server/test/watchdog.test.ts
@@ -19,6 +19,7 @@ type WaitableTransaction = {
 type WatchdogInternals = {
   getTokenBalance: (...args: unknown[]) => Promise<bigint>;
   getTokenAllowance: (...args: unknown[]) => Promise<bigint>;
+  getVaultMaxWithdraw: (...args: unknown[]) => Promise<bigint>;
   findRequiredAmountRawGeneric: (...args: unknown[]) => Promise<bigint | null>;
   previewResultingHf: (...args: unknown[]) => Promise<bigint>;
   previewResultingHfMorpho: (...args: unknown[]) => Promise<bigint>;
@@ -387,6 +388,7 @@ function stubPreRescueEvaluation(
   const internals = getWatchdogInternals(watchdog);
   Object.assign(internals, {
     getTokenBalance: async () => 0n, // empty wallet
+    getVaultMaxWithdraw: async () => 1_000_000_000n, // 1000 USDC withdrawable
     findRequiredAmountRawGeneric: async () => 200_000_000n, // need 200 USDC (6 decimals)
     previewResultingHf: async () => 1_900_000_000_000_000_000n,
     getGasPriceGwei: async () => 10,
@@ -508,7 +510,69 @@ test('pre-rescue: skips when no matching vault', async () => {
 
   const log = watchdog.getLog();
   assert.equal(log[0]?.action, 'skipped');
-  assert.match(log[0]?.reason ?? '', /no Morpho vault holding/);
+  assert.match(log[0]?.reason ?? '', /no Morpho vault with withdrawable/);
+});
+
+test('pre-rescue: capacity calc uses wallet + vault (does not under-skip)', async () => {
+  // Scenario from review feedback: need 800 USDC, wallet has 400, maxVaultWithdraw=500.
+  // Old behavior wrongly skipped because 500 alone didn't reach target HF.
+  // New behavior must run findRequiredAmount with bound = min(wallet+vault, maxRepay)
+  // = min(400 + 500, 500 default maxRepay) = 500, and search returns 500 which is
+  // achievable. Wallet 400 < needed 500 → withdraw shortfall 100.
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+      maxVaultWithdrawAmount: 500,
+      maxRepayAmount: 500,
+    }),
+  );
+  let boundSeen: bigint | null = null;
+  stubPreRescueEvaluation(watchdog, {
+    getTokenBalance: async () => 400_000_000n, // 400 USDC in wallet
+    getVaultMaxWithdraw: async () => 10_000_000_000n, // plenty in vault
+    findRequiredAmountRawGeneric: async (...args: unknown[]) => {
+      boundSeen = args[2] as bigint;
+      return 500_000_000n; // need 500 total
+    },
+  });
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault()]);
+
+  assert.equal(boundSeen, 500_000_000n);
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'vault-withdraw');
+  assert.equal(log[0]?.repayAmount, 100); // shortfall = 500 - 400
+});
+
+test('pre-rescue: caps withdrawal at ERC-4626 maxWithdraw', async () => {
+  // Vault reports totalAssets=10_000 via Morpho API but maxWithdraw returns
+  // only 75 USDC for this user. The withdrawal must respect maxWithdraw.
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+      maxVaultWithdrawAmount: 500,
+    }),
+  );
+  let capturedAmount: bigint | null = null;
+  stubPreRescueEvaluation(watchdog, {
+    getVaultMaxWithdraw: async () => 75_000_000n, // 75 USDC withdrawable
+    findRequiredAmountRawGeneric: async () => 75_000_000n, // capped at capacity=75
+    submitVaultWithdrawTransaction: async (...args: unknown[]) => {
+      capturedAmount = args[3] as bigint;
+      return '0xvaulttx';
+    },
+  });
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault({ totalAssets: 10_000 })]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'vault-withdraw');
+  assert.equal(log[0]?.repayAmount, 75);
+  assert.equal(capturedAmount, 75_000_000n);
 });
 
 test('pre-rescue: disabled flag bypasses layer 0 entirely', async () => {

--- a/packages/server/test/watchdog.test.ts
+++ b/packages/server/test/watchdog.test.ts
@@ -1,12 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import type { LoanPosition } from '@aave-monitor/core';
+import type { LoanPosition, MorphoVaultPosition } from '@aave-monitor/core';
 import { Watchdog } from '../src/watchdog.js';
 import type { WatchdogConfig } from '../src/storage.js';
 import type { TelegramClient } from '../src/telegram.js';
 
 const WALLET = '0x1111111111111111111111111111111111111111';
 const RESCUE_CONTRACT = '0x2222222222222222222222222222222222222222';
+const VAULT_WITHDRAW_CONTRACT = '0x3333333333333333333333333333333333333333';
+const VAULT_ADDRESS = '0x4444444444444444444444444444444444444444';
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const PROJECTED_HF_WAD = 1_900_000_000_000_000_000n;
 
 type WatchdogReceipt = { status: number; hash: string };
@@ -18,9 +21,11 @@ type WatchdogInternals = {
   getTokenAllowance: (...args: unknown[]) => Promise<bigint>;
   findRequiredAmountRawGeneric: (...args: unknown[]) => Promise<bigint | null>;
   previewResultingHf: (...args: unknown[]) => Promise<bigint>;
+  previewResultingHfMorpho: (...args: unknown[]) => Promise<bigint>;
   getGasPriceGwei: (...args: unknown[]) => Promise<number>;
   getEthBalance: (...args: unknown[]) => Promise<number>;
   submitRescueTransaction: (...args: unknown[]) => Promise<string>;
+  submitVaultWithdrawTransaction: (...args: unknown[]) => Promise<string>;
   waitForReceiptOrReplacement: (
     tx: WaitableTransaction,
     expectedTo: string,
@@ -46,6 +51,82 @@ function createConfig(overrides: Partial<WatchdogConfig> = {}): WatchdogConfig {
     rescueContract: RESCUE_CONTRACT,
     morphoRescueContract: '',
     maxGasGwei: 50,
+    preRescueEnabled: false,
+    preRescueTriggerHF: 1.7,
+    vaultWithdrawContract: '',
+    maxVaultWithdrawAmount: 500,
+    ...overrides,
+  };
+}
+
+function createLoanWithHF(targetHF: number): LoanPosition {
+  // HF = liqThreshold * suppliedUsd / borrowedUsd. With lt=0.75, supplied=3200:
+  // borrowedUsd = 0.75 * 3200 / targetHF
+  const borrowedUsd = (0.75 * 3200) / targetHF;
+  return {
+    id: 'loan-1',
+    marketName: 'proto_mainnet_v3',
+    borrowed: [
+      {
+        symbol: 'USDC',
+        address: USDC_ADDRESS,
+        decimals: 6,
+        amount: borrowedUsd,
+        usdPrice: 1,
+        usdValue: borrowedUsd,
+        collateralEnabled: false,
+        maxLTV: 0,
+        liqThreshold: 0,
+        supplyRate: 0,
+        borrowRate: 0.05,
+      },
+    ],
+    supplied: [
+      {
+        symbol: 'WBTC',
+        address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+        decimals: 8,
+        amount: 0.08,
+        usdPrice: 40_000,
+        usdValue: 3_200,
+        collateralEnabled: true,
+        maxLTV: 0.7,
+        liqThreshold: 0.75,
+        supplyRate: 0,
+        borrowRate: 0,
+      },
+    ],
+    totalSuppliedUsd: 3_200,
+    totalBorrowedUsd: borrowedUsd,
+  };
+}
+
+function createVault(overrides: Partial<MorphoVaultPosition> = {}): MorphoVaultPosition {
+  return {
+    id: 'vault-1',
+    kind: 'morpho-vault',
+    protocol: 'morpho',
+    vaultAddress: VAULT_ADDRESS,
+    vaultName: 'Gauntlet USDC Prime',
+    vaultSymbol: 'gtUSDC',
+    asset: {
+      symbol: 'USDC',
+      address: USDC_ADDRESS,
+      decimals: 6,
+      amount: 1000,
+      usdPrice: 1,
+      usdValue: 1000,
+      collateralEnabled: false,
+      maxLTV: 0,
+      liqThreshold: 0,
+      supplyRate: 0,
+      borrowRate: 0,
+    },
+    shares: 1000,
+    totalAssets: 1000,
+    totalAssetsUsd: 1000,
+    apy: 0.05,
+    netApy: 0.05,
     ...overrides,
   };
 }
@@ -295,4 +376,177 @@ test('failed rescue tx logs error, sets cooldown, and notifies', async () => {
   assert.equal(messages.length, 1);
   assert.match(messages[0]!, /Rescue failed/);
   assert.match(messages[0]!, /Borrow rate: <b>5\.00%<\/b>/);
+});
+
+// ---------- Layer 0: pre-rescue vault withdrawal ----------
+
+function stubPreRescueEvaluation(
+  watchdog: Watchdog,
+  overrides: Partial<WatchdogInternals> = {},
+): WatchdogInternals {
+  const internals = getWatchdogInternals(watchdog);
+  Object.assign(internals, {
+    getTokenBalance: async () => 0n, // empty wallet
+    findRequiredAmountRawGeneric: async () => 200_000_000n, // need 200 USDC (6 decimals)
+    previewResultingHf: async () => 1_900_000_000_000_000_000n,
+    getGasPriceGwei: async () => 10,
+    getEthBalance: async () => 1,
+    submitVaultWithdrawTransaction: async () => '0xvaulttx',
+    ...overrides,
+  });
+  return internals;
+}
+
+test('pre-rescue: HF above preRescueTriggerHF does nothing', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  stubPreRescueEvaluation(watchdog);
+
+  await watchdog.evaluate(createLoanWithHF(2.0), WALLET, [createVault()]);
+
+  assert.equal(watchdog.getLog().length, 0);
+});
+
+test('pre-rescue: HF below triggerHF falls through to layer 1', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: true,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  // Set up layer-1 stubs
+  stubEvaluation(watchdog, {
+    findRequiredAmountRawGeneric: async () => 2_500_000n,
+    previewResultingHf: async (...args: unknown[]) => {
+      const amount = args.at(-1);
+      return typeof amount === 'bigint' && amount > 0n
+        ? 1_900_000_000_000_000_000n
+        : 1_500_000_000_000_000_000n;
+    },
+  });
+
+  await watchdog.evaluate(createLoanWithHF(1.5), WALLET, [createVault()]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'dry-run');
+});
+
+test('pre-rescue: HF in buffer band with matching vault triggers vault withdrawal (live)', async () => {
+  const { watchdog, messages } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  stubPreRescueEvaluation(watchdog);
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault()]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'vault-withdraw');
+  assert.equal(log[0]?.txHash, '0xvaulttx');
+  assert.equal(log[0]?.vaultAddress, VAULT_ADDRESS);
+  assert.equal(log[0]?.repayAmount, 200);
+  assert.equal(messages.length, 1);
+  assert.match(messages[0]!, /Pre-rescue vault withdrawal/);
+});
+
+test('pre-rescue: dry-run logs vault-withdraw-dry-run', async () => {
+  const { watchdog, messages } = createWatchdog(
+    createConfig({
+      dryRun: true,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  stubPreRescueEvaluation(watchdog);
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault()]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'vault-withdraw-dry-run');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0]!, /Pre-rescue DRY RUN/);
+});
+
+test('pre-rescue: skips when wallet already holds enough', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  stubPreRescueEvaluation(watchdog, {
+    getTokenBalance: async () => 500_000_000n, // 500 USDC, more than 200 needed
+  });
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault()]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'skipped');
+  assert.match(log[0]?.reason ?? '', /wallet already holds/);
+});
+
+test('pre-rescue: skips when no matching vault', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+  stubPreRescueEvaluation(watchdog);
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, []);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'skipped');
+  assert.match(log[0]?.reason ?? '', /no Morpho vault holding/);
+});
+
+test('pre-rescue: disabled flag bypasses layer 0 entirely', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      preRescueEnabled: false,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+    }),
+  );
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault()]);
+
+  // HF=1.67 is above triggerHF=1.65 so layer 1 also skips. With preRescue off, no log.
+  assert.equal(watchdog.getLog().length, 0);
+});
+
+test('pre-rescue: caps withdrawal at maxVaultWithdrawAmount', async () => {
+  const { watchdog } = createWatchdog(
+    createConfig({
+      dryRun: false,
+      preRescueEnabled: true,
+      vaultWithdrawContract: VAULT_WITHDRAW_CONTRACT,
+      maxVaultWithdrawAmount: 50,
+    }),
+  );
+  let capturedAmount: bigint | null = null;
+  stubPreRescueEvaluation(watchdog, {
+    findRequiredAmountRawGeneric: async () => 50_000_000n, // capped by maxVaultWithdrawRaw=50_000_000n
+    submitVaultWithdrawTransaction: async (...args: unknown[]) => {
+      capturedAmount = args[3] as bigint;
+      return '0xvaulttx';
+    },
+  });
+
+  await watchdog.evaluate(createLoanWithHF(1.67), WALLET, [createVault({ totalAssets: 10_000 })]);
+
+  const log = watchdog.getLog();
+  assert.equal(log[0]?.action, 'vault-withdraw');
+  assert.equal(log[0]?.repayAmount, 50);
+  assert.equal(capturedAmount, 50_000_000n);
 });

--- a/src/components/ServerSettings.tsx
+++ b/src/components/ServerSettings.tsx
@@ -111,7 +111,7 @@ function validateConfig(config: AlertConfig): string | null {
   if (!isPositiveFinite(watchdog.preRescueTriggerHF)) {
     return 'Pre-rescue trigger HF must be a positive number.';
   }
-  if (watchdog.preRescueTriggerHF <= watchdog.triggerHF) {
+  if (watchdog.preRescueEnabled && watchdog.preRescueTriggerHF <= watchdog.triggerHF) {
     return 'Pre-rescue trigger HF must be greater than trigger HF.';
   }
   if (!isPositiveFinite(watchdog.maxVaultWithdrawAmount)) {

--- a/src/components/ServerSettings.tsx
+++ b/src/components/ServerSettings.tsx
@@ -108,6 +108,25 @@ function validateConfig(config: AlertConfig): string | null {
     return 'Watchdog max gas must be a positive number.';
   }
 
+  if (!isPositiveFinite(watchdog.preRescueTriggerHF)) {
+    return 'Pre-rescue trigger HF must be a positive number.';
+  }
+  if (watchdog.preRescueTriggerHF <= watchdog.triggerHF) {
+    return 'Pre-rescue trigger HF must be greater than trigger HF.';
+  }
+  if (!isPositiveFinite(watchdog.maxVaultWithdrawAmount)) {
+    return 'Watchdog max vault withdraw amount must be a positive number.';
+  }
+  if (
+    watchdog.vaultWithdrawContract &&
+    !/^0x[a-fA-F0-9]{40}$/.test(watchdog.vaultWithdrawContract)
+  ) {
+    return 'Vault withdraw contract must be a valid Ethereum address.';
+  }
+  if (watchdog.preRescueEnabled && !/^0x[a-fA-F0-9]{40}$/.test(watchdog.vaultWithdrawContract)) {
+    return 'Enable pre-rescue only after configuring the vault withdraw contract.';
+  }
+
   return null;
 }
 
@@ -682,6 +701,86 @@ function ServerSettingsPanel({ onClose }: { onClose: () => void }) {
                         className="w-[120px]"
                       />
                     </label>
+
+                    <div className="mt-2 grid gap-3 rounded-md border border-border/60 p-3">
+                      <div className="text-xs font-semibold uppercase text-muted-foreground">
+                        Pre-rescue (Morpho vault withdrawal)
+                      </div>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={config.watchdog.preRescueEnabled}
+                          onChange={() =>
+                            updateWatchdog(
+                              { preRescueEnabled: !config.watchdog.preRescueEnabled },
+                              { persist: true },
+                            )
+                          }
+                          className="accent-primary"
+                        />
+                        Enable pre-rescue vault withdrawal
+                      </label>
+
+                      <label className="grid gap-1.5 text-sm">
+                        <span className="text-muted-foreground">Pre-rescue trigger HF</span>
+                        <Input
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          value={config.watchdog.preRescueTriggerHF}
+                          onChange={(e) =>
+                            updateWatchdog({ preRescueTriggerHF: Number(e.target.value) })
+                          }
+                          onBlur={(e) =>
+                            updateWatchdog(
+                              { preRescueTriggerHF: Number(e.target.value) },
+                              { persist: true },
+                            )
+                          }
+                          className="w-[120px]"
+                        />
+                      </label>
+
+                      <label className="grid gap-1.5 text-sm">
+                        <span className="text-muted-foreground">
+                          Max vault withdraw per action (debt token)
+                        </span>
+                        <Input
+                          type="number"
+                          min="1"
+                          step="1"
+                          value={config.watchdog.maxVaultWithdrawAmount}
+                          onChange={(e) =>
+                            updateWatchdog({ maxVaultWithdrawAmount: Number(e.target.value) })
+                          }
+                          onBlur={(e) =>
+                            updateWatchdog(
+                              { maxVaultWithdrawAmount: Number(e.target.value) },
+                              { persist: true },
+                            )
+                          }
+                          className="w-[120px]"
+                        />
+                      </label>
+
+                      <label className="grid gap-1.5 text-sm">
+                        <span className="text-muted-foreground">Vault withdraw contract</span>
+                        <Input
+                          value={config.watchdog.vaultWithdrawContract}
+                          onChange={(e) =>
+                            updateWatchdog({ vaultWithdrawContract: e.target.value.trim() })
+                          }
+                          onBlur={(e) =>
+                            updateWatchdog(
+                              { vaultWithdrawContract: e.target.value.trim() },
+                              { persist: true },
+                            )
+                          }
+                          placeholder="0x..."
+                          className="font-mono text-xs"
+                        />
+                      </label>
+                    </div>
                   </div>
                 ) : null}
               </section>


### PR DESCRIPTION
## Context

Today the watchdog can only repay debt using debt-token balance already sitting in the monitored wallet (layer 1). If those funds are deployed into a Morpho ERC-4626 vault (e.g. Gauntlet USDC Prime), the watchdog will log "No available USDC" and skip the rescue even though the operator has plenty of capital to defend the loan.

This PR adds a pre-rescue stage (layer 0) that fires *before* HF reaches the layer-1 trigger. When HF is in the buffer band ``[triggerHF, preRescueTriggerHF)``, the watchdog looks for a Morpho vault holding the loan's debt token and pre-emptively redeems just enough vault shares to cover the projected rescue. The redeemed assets land in the monitored wallet. If HF later crosses ``triggerHF``, the existing layer-1 rescue uses those wallet funds with no change to its code path. If HF recovers, the funds simply remain in the wallet for the operator to redeposit — the layer-0 withdrawal is intentionally one-way and non-atomic with rescue.

The existing rescue contracts and the layer-1 flow are **not modified**. Layer 0 is a strictly additive step that runs before the existing ``triggerHF`` check.

## Approach

### 1. New on-chain helper: ``MorphoVaultWithdrawV1.sol``

New contract at ``packages/rescue-contract/src/MorphoVaultWithdrawV1.sol`` modeled on ``MorphoAtomicRepayV1``:

- Same owner / executor split (``owner`` = monitored wallet, ``executor`` = bot hot wallet).
- ``setSupportedVault(address vault, bool enabled)`` allowlist, mirroring ``setSupportedMarket``.
- ``withdraw(WithdrawParams { user, vault, assets, deadline })``, callable only by ``executor``:
  - Validates ``user == owner``, deadline, supported vault, non-zero assets.
  - Calls ``IERC4626(vault).withdraw(assets, user, user)`` — Morpho MetaMorpho vaults are ERC-4626 compliant, so this redeems shares from ``user`` and sends underlying assets straight to ``user``'s wallet. The contract itself never custodies the funds.
- ``previewMaxWithdraw(vault, user) view returns (uint256)`` thin wrapper over ``IERC4626.maxWithdraw`` for off-chain capping.

Owner pre-approves the helper on vault shares (``vault.approve(helper, type(uint256).max)``). The executor key only needs to call ``withdraw(...)``; it never touches vault shares directly. A single deployed instance per monitored wallet supports many vaults via ``setSupportedVault``.

### 2. Config additions (``WatchdogConfig``)

```
preRescueEnabled: boolean;          // master switch for layer 0
preRescueTriggerHF: number;          // default 1.7
vaultWithdrawContract: string;       // address of MorphoVaultWithdrawV1
maxVaultWithdrawAmount: number;      // per-loan, debt-token denominated cap
```

Defaults hydrated in ``constants.ts``/``storage.ts``; env overrides ``WATCHDOG_PRE_TRIGGER_HF``, ``WATCHDOG_VAULT_WITHDRAW_CONTRACT``, ``WATCHDOG_MAX_VAULT_WITHDRAW_AMOUNT``; zod schema updated; dashboard ``ServerSettings`` form gains four new controls in a dedicated "Pre-rescue" subsection with cross-field validation.

### 3. Watchdog evaluation flow

``Watchdog.evaluate`` now accepts ``vaults: MorphoVaultPosition[]`` and ``monitor.ts`` passes them through.

A new step runs *before* the layer-1 ``triggerHF`` early return:

1. If ``!preRescueEnabled`` or HF outside buffer band → fall through.
2. Separate cooldown key (``${wallet}-${loan}-prerescue``).
3. Reuse existing ``previewFn`` + ``findRequiredAmountRawGeneric`` to compute ``neededRaw`` capped at ``maxVaultWithdrawAmount``.
4. Read wallet debt-token balance. If wallet already covers ``neededRaw``, skip.
5. Pick the source vault: filter to ``asset.address == debtToken``, pick the entry with the largest ``totalAssets``. If none → ``skipped``.
6. Compute ``withdrawRaw = min(shortfall, vaultAssets, maxVaultWithdraw)``.
7. Honor ``dryRun`` (log + Telegram preview) or submit ``MorphoVaultWithdrawV1.withdraw(...)`` signed by executor.
8. Record outcome with new ``vault-withdraw`` / ``vault-withdraw-dry-run`` log actions and a new optional ``vaultAddress`` field. Send a Telegram notice.
9. Set the prerescue cooldown timestamp; return without invoking layer 1 this poll.

``getStatusSummary()`` now also surfaces ``preRescueEnabled``, ``preRescueTriggerHF``, and ``vaultWithdrawContract`` so ``/watchdog`` Telegram + ``GET /api/watchdog/status`` reflect layer-0 state.

### 4. Tests

Eight new tests in ``packages/server/test/watchdog.test.ts`` covering:

- HF above ``preRescueTriggerHF`` → no action.
- HF in buffer band, wallet already funded → skip.
- HF in buffer band, vault available → submits ``withdraw`` (live + dry-run paths).
- HF in buffer band, no matching vault → ``skipped`` log entry.
- HF below ``triggerHF`` → layer 0 bypassed, layer 1 runs as before (regression).
- Disabled ``preRescueEnabled`` → existing behavior unchanged.
- ``maxVaultWithdrawAmount`` cap respected.

### 5. Files

- ``packages/rescue-contract/src/MorphoVaultWithdrawV1.sol`` *(new)*
- ``packages/aave-core/src/types.ts``, ``constants.ts``
- ``packages/server/src/storage.ts``, ``configSchema.ts``, ``watchdog.ts``, ``monitor.ts``
- ``src/components/ServerSettings.tsx``
- ``packages/server/test/watchdog.test.ts``
- ``docs/watchdog-user-manual.md``

## Test plan

- [x] ``yarn typecheck`` — passes
- [x] ``yarn lint`` — passes
- [x] ``yarn format:check`` — passes
- [x] ``yarn test`` — 123/123 pass (8 new layer-0 tests + all existing tests untouched)
- [ ] Deploy ``MorphoVaultWithdrawV1`` to a fork, ``setSupportedVault`` for a USDC vault, approve vault shares, set ``preRescueEnabled: true`` + ``dryRun: true``, force a low HF and verify a ``vault-withdraw-dry-run`` entry appears in ``/api/watchdog/status`` + Telegram
- [ ] Live smoke test on mainnet with tiny ``maxVaultWithdrawAmount``: confirm executor tx redeems vault shares, USDC arrives in monitored wallet, subsequent layer-1 rescue (if triggered) consumes it
- [ ] Regression check with ``preRescueEnabled: false`` — existing watchdog flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)